### PR TITLE
Add the FTS cron job to helm

### DIFF
--- a/rucio-daemons/templates/renew-fts-account.yaml
+++ b/rucio-daemons/templates/renew-fts-account.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ftsRenewal.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-rucio-edit
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-rucio-edit
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-rucio-edit
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ftsRenewal.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: renew-fts-proxy
+spec:
+  schedule: "12 */6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Release.Name }}-rucio-edit
+          volumes:
+          - name: usercert
+            secret:
+              secretName: fts-cert
+          - name: userkey
+            secret:
+              secretName: fts-key
+          containers:
+            - name: renew-fts-cron
+              image: "{{ .Values.ftsRenewal.image.repository }}:{{ .Values.ftsRenewal.image.tag }}"
+              imagePullPolicy: {{ .Values.ftsRenewal.image.pullPolicy }}
+              volumeMounts:
+                - name: usercert
+                  mountPath: /opt/rucio/certs/
+                - name: userkey
+                  mountPath: /opt/rucio/keys/
+              env:
+                - name: RUCIO_FTS_VOMS
+                  value: {{ .Values.ftsRenewal.voms | quote }}
+                - name: RUCIO_FTS_SERVERS
+                  value: {{ .Values.ftsRenewal.servers | default "https://fts3.cern.ch:8446" | quote }}
+                - name: RUCIO_FTS_SECRETS
+                  value: "{{ .Release.Name }}-rucio-x509up"
+          restartPolicy: OnFailure
+{{ end }}

--- a/rucio-daemons/values.yaml
+++ b/rucio-daemons/values.yaml
@@ -79,6 +79,16 @@ reaper:
   threadsPerWorker: 4
   includeRses: ""
 
+ftsRenewal:
+  enabled: 0
+  image:
+    repository: ericvaandering/rucio-cron
+    tag: latest
+    pullPolicy: Always
+  voms: "cms:/cms/Role=production"
+  servers: "https://fts3-devel.cern.ch:8446,https://cmsfts3.fnal.gov:8446,https://fts3.cern.ch:8446,https://lcgfts3.gridpp.rl.ac.uk:8446,https://fts3-pilot.cern.ch:8446"
+
+
 ## common config values used to configure the Rucio daemons
 config:
   # accounts:


### PR DESCRIPTION
@tbeerman here is the helm-chart part of the code to add the FTS CronJob part of the renewal process. What do you think? We can change the defaults if you want something better.