### PR TITLE
Use official image, make cronjob depend on release name

### DIFF
--- a/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: renew-fts-proxy
+  name: {{ .Release.Name }}-renew-fts-proxy
 spec:
   schedule: "12 */6 * * *"
   jobTemplate:

--- a/rucio-daemons/values.yaml
+++ b/rucio-daemons/values.yaml
@@ -82,7 +82,7 @@ reaper:
 ftsRenewal:
   enabled: 0
   image:
-    repository: ericvaandering/rucio-cron
+    repository: rucio/fts-cron
     tag: latest
     pullPolicy: Always
   voms: "cms:/cms/Role=production"


### PR DESCRIPTION
Sorry @tbeerman . One mistake, for my setup where I have two releases of daemons running, I need two cron jobs with different names.