### PR TITLE
Add parameters to expose HTTPD error_log

### DIFF
--- a/rucio-server/templates/auth_deployment.yaml
+++ b/rucio-server/templates/auth_deployment.yaml
@@ -32,6 +32,8 @@ spec:
       - name: aliases
         configMap:
           name: {{ template "rucio.fullname" . }}-auth-aliases
+      - name: httpdlog
+        emptyDir: {}
 {{- if .Values.authServer.useSSL }}
       - name: hostcert
         secret:
@@ -44,6 +46,14 @@ spec:
           secretName: ca
 {{- end }}
       containers:
+{{- if .Values.exposeErrorLogs.authServer }}
+        - name: httpd-error-log
+          image: busybox
+          args: [/bin/sh, -c, 'tail -n+1 -f /var/log/httpd/error_log']
+          volumeMounts:
+          - name: httpdlog
+            mountPath: /var/log/httpd
+{{- end }}
         - name: {{ .Chart.Name }}-auth
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -55,6 +65,8 @@ spec:
               containerPort: 443
               protocol: TCP
           volumeMounts:
+            - name: httpdlog
+              mountPath: /var/log/httpd
             - name: aliases
               mountPath: /opt/rucio/etc/aliases.conf
               subPath: aliases.conf

--- a/rucio-server/templates/deployment.yaml
+++ b/rucio-server/templates/deployment.yaml
@@ -28,10 +28,24 @@ spec:
         app: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
     spec:
+      volumes:
+      - name: httpdlog
+        emptyDir: {}      
       containers:
+{{- if .Values.exposeErrorLogs.server }}
+        - name: httpd-error-log
+          image: busybox
+          args: [/bin/sh, -c, 'tail -n+1 -f /var/log/httpd/error_log']
+          volumeMounts:
+          - name: httpdlog
+            mountPath: /var/log/httpd
+{{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+          - name: httpdlog
+            mountPath: /var/log/httpd
           ports:
             - name: http
               containerPort: 80

--- a/rucio-server/values.yaml
+++ b/rucio-server/values.yaml
@@ -7,6 +7,11 @@ replicaCount: 2
 ## authReplicaCount gives the number of authentication server pods to run
 authReplicaCount: 1
 
+# When set, run extra busybox containers in the relevant pods to also expose the error logs
+exposeErrorLogs:
+  server: True
+  authServer: True
+
 authServer:
   # Run the authorization server on port 443 instead of 80 and accept X509 certificates and proxies
   useSSL: false


### PR DESCRIPTION
This adds an extra log per pod with the error_logs from the server and auth server. You can turn it off by setting the values to False