### PR TITLE
Move metrics exporter resources config into the encapsulating block.

### DIFF
--- a/rucio-server/templates/deployment.yaml
+++ b/rucio-server/templates/deployment.yaml
@@ -74,9 +74,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.monitoring.exporterPort }}
               protocol: TCP
-{{- end }}
           resources:
 {{ toYaml .Values.metricsExporterResources | indent 12 }}
+{{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
Found a bug that causes resources for the metrics exporter to be inserted into the template output, regardless of if the exporter is enabled.