### PR TITLE
Make explicit jobber config name and fix UI API version

### DIFF
--- a/rucio-probes/templates/deployment.yaml
+++ b/rucio-probes/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       volumes:
         - configMap:
             defaultMode: 0644
-            name: jobber-config
+            name: {{ include "rucio-probes.fullname" . }}-jobber-config
           name: config
 {{- if hasKey .Values.probeSettings "ftsProxySecret" }}
         - name: proxy-volume

--- a/rucio-probes/templates/jobber-configmap.yaml
+++ b/rucio-probes/templates/jobber-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: jobber-config
+  name: {{ include "rucio-probes.fullname" . }}-jobber-config
 data:
   dot-jobber.yaml: |+
     ## This is your jobfile: use it to tell Jobber what jobs you want it to

--- a/rucio-ui/templates/deployment.yaml
+++ b/rucio-ui/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "rucio.fullname" . }}


### PR DESCRIPTION
A couple of issues I found. One is that jobber-config was not specific enough. And an issue with helm3