### PR TITLE
Add the ability to turn on VO specific probes

### DIFF
--- a/rucio-probes/templates/jobber-configmap.yaml
+++ b/rucio-probes/templates/jobber-configmap.yaml
@@ -71,3 +71,11 @@ data:
         onError: {{ $config.onError | default "Continue" }}
 {{- end }}
 {{- end }}
+{{- range $probe, $config := .Values.voProbes }}
+{{ if gt $config.interval 0.0 }}
+      {{ $probe }}:
+        cmd: /probes/{{ $config.voName }}/{{ $probe }}
+        time: 'R */{{ $config.interval }} * * * *'
+        onError: {{ $config.onError | default "Continue" }}
+{{- end }}
+{{- end }}

--- a/rucio-probes/values.yaml
+++ b/rucio-probes/values.yaml
@@ -164,6 +164,14 @@ probes:
   check_xcache:
     interval: 0
 
+voProbes: {}
+  # Here list other probes following the scheme above for the common probes. 
+  # In addition to "interval" define which VO
+  # These probes will be run from the /probes/someVO/ directory instead of probes/common
+  # check_something:
+  #   interval: 1
+  #   voName: someVO
+
 strategy:
   type: RollingUpdate
   rollingUpdate:


### PR DESCRIPTION
With the agreement with @dchristidis that CMS probes go in cms/ at least at first, we need a way to run them. This sets up a parallel list of probes to run and you can run probes from any and all VOs.