### PR TITLE
Make the cron schedule a configurable parameter

### DIFF
--- a/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-renew-fts-proxy
 spec:
-  schedule: "12 */6 * * *"
+  schedule: "{{ .Values.ftsRenewal.schedule }}"
   jobTemplate:
     spec:
       template:

--- a/rucio-daemons/values.yaml
+++ b/rucio-daemons/values.yaml
@@ -350,6 +350,7 @@ necromancer:
 
 ftsRenewal:
   enabled: 0
+  schedule: "12 */6 * * *"
   image:
     repository: rucio/fts-cron
     tag: latest


### PR DESCRIPTION
Make the FTS renewal a configurable parameter. There is a race condition in FTS and if you renew from multiple places at the same time you can lose the proxy altogether.