### PR TITLE
add support for fts secrets in rucio-server chart

### DIFF
--- a/rucio-server/Chart.yaml
+++ b/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 0.3.0
+version: 0.4.0
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/rucio-server/README.md
+++ b/rucio-server/README.md
@@ -48,6 +48,15 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
       -f values.yaml \
       rucio/rucio-server
 
+
+## Certificates
+
+Some functions require certificates and CAs to work. They expect specific secrets that need to be created before the pod can start.
+
+### API calls to FTS
+
+To update rule priority in FTS, the API call must be authenticated. The configuration is identical to the one of the [conveyor](https://github.com/rucio/helm-charts/tree/master/rucio-daemons#conveyor) daemon. 
+
 ## Service
 
 By default the servers pods are listening on port 80 using plain HTTP and the default services are of type `ClusterIP` on port 80. You can adapt this separately for the api, authentication and trace servers. To run the pods with HTTPS you will first have to install the necessary key, cert and CA files for the corresponding servers:

--- a/rucio-server/templates/deployment.yaml
+++ b/rucio-server/templates/deployment.yaml
@@ -94,6 +94,10 @@ spec:
           resources:
 {{ toYaml .Values.serverResources | indent 12 }}
           volumeMounts:
+          - name: proxy-volume
+            mountPath: /opt/proxy
+          - name: ca-volume
+            mountPath: /opt/certs
           - name: httpdlog
             mountPath: /var/log/httpd
           {{- range $key, $val := .Values.additionalSecrets }}

--- a/rucio-server/templates/deployment.yaml
+++ b/rucio-server/templates/deployment.yaml
@@ -33,6 +33,12 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
+      - name: proxy-volume
+        secret:
+          secretName: {{ .Release.Name }}-rucio-x509up
+      - name: ca-volume
+        secret:
+          secretName: {{ .Release.Name }}-rucio-ca-bundle
       - name: httpdlog
         emptyDir: {}
       {{- range $key, $val := .Values.additionalSecrets }}

--- a/rucio-server/templates/renew-fts-account.yaml
+++ b/rucio-server/templates/renew-fts-account.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ftsRenewal.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-rucio-edit
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-rucio-edit
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-rucio-edit
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/rucio-server/templates/renew-fts-cronjob.yaml
+++ b/rucio-server/templates/renew-fts-cronjob.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.ftsRenewal.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-renew-fts-proxy
+spec:
+  schedule: "{{ .Values.ftsRenewal.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Release.Name }}-rucio-edit
+          volumes:
+{{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
+          - name: longproxy
+            secret:
+              secretName: {{ .Release.Name }}-longproxy
+{{- else }}
+          - name: usercert
+            secret:
+              secretName: {{ .Release.Name }}-fts-cert
+          - name: userkey
+            secret:
+              secretName: {{ .Release.Name }}-fts-key
+{{- end }}
+{{- range $key, $val := .Values.persistentVolumes }}
+          - name: {{ $key }}
+            persistentVolumeClaim:
+              claimName: {{ $val.name }}
+{{- end}}
+          containers:
+            - name: renew-fts-cron
+              image: "{{ .Values.ftsRenewal.image.repository }}:{{ .Values.ftsRenewal.image.tag }}"
+              imagePullPolicy: {{ .Values.ftsRenewal.image.pullPolicy }}
+              volumeMounts:
+{{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
+                - name: longproxy
+                  mountPath: /opt/rucio/certs/
+{{- else }}
+                - name: usercert
+                  mountPath: /opt/rucio/certs/
+                - name: userkey
+                  mountPath: /opt/rucio/keys/
+{{- end }}
+{{- range $key, $val := .Values.persistentVolumes }}
+                - name: {{ $key }}
+                  mountPath: {{ $val.mountPath }}
+{{- end}}
+              env:
+                {{- range $key1, $val1 := .Values.optional_config }}
+                - name: {{ $key1 | upper }}
+                  value: "{{ $val1  }}"
+                {{- end}}
+                - name: RUCIO_VO
+                  value: {{ .Values.ftsRenewal.vo | quote }}
+                - name: RUCIO_FTS_VOMS
+                  value: {{ .Values.ftsRenewal.voms | quote }}
+                - name: RUCIO_FTS_SERVERS
+                  value: {{ .Values.ftsRenewal.servers | quote }}
+                - name: RUCIO_FTS_SECRETS
+                  value: "{{ .Release.Name }}-rucio-x509up"
+{{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
+                - name: RUCIO_LONG_PROXY
+                  value: {{ .Values.ftsRenewal.longProxy | quote }}
+{{- end }}
+          restartPolicy: OnFailure
+{{ end }}

--- a/rucio-server/values.yaml
+++ b/rucio-server/values.yaml
@@ -115,7 +115,7 @@ metricsExporterResources:
 
 ftsRenewal:
   enabled: 0
-  schedule: "12 */6 * * *"
+  schedule: "42 */6 * * *"
   image:
     repository: rucio/fts-cron
     tag: latest

--- a/rucio-server/values.yaml
+++ b/rucio-server/values.yaml
@@ -113,6 +113,17 @@ metricsExporterResources:
    cpu: 20m
    memory: 20Mi
 
+ftsRenewal:
+  enabled: 0
+  schedule: "12 */6 * * *"
+  image:
+    repository: rucio/fts-cron
+    tag: latest
+    pullPolicy: Always
+  vo: "cms"
+  voms: "cms:/cms/Role=production"
+  servers: "https://fts3-devel.cern.ch:8446,https://cmsfts3.fnal.gov:8446,https://fts3.cern.ch:8446,https://lcgfts3.gridpp.rl.ac.uk:8446,https://fts3-pilot.cern.ch:8446"
+
 automaticRestart:
   enabled: 0
   image:


### PR DESCRIPTION
The writers need to contact fts when update-rule-priority is called.