### PR TITLE
Backport versions from gh-pages branch

### DIFF
--- a/rucio-daemons/Chart.yaml
+++ b/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 0.2.0
+version: 1.2.8
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/rucio-server/Chart.yaml
+++ b/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 0.4.0
+version: 1.1.3
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/rucio-ui/Chart.yaml
+++ b/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 0.1.0
+version: 0.3.1
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:


### PR DESCRIPTION
the correct versions are in gh-pages, because it's the branch used
to server production helm charts.