### PR TITLE
rucio-server: only mount x509 key and ca sercrets if fts renewal enabled

### DIFF
--- a/rucio-server/Chart.yaml
+++ b/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.1.3
+version: 1.1.4
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/rucio-server/templates/deployment.yaml
+++ b/rucio-server/templates/deployment.yaml
@@ -33,12 +33,14 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
+      {{- if .Values.ftsRenewal.enabled -}}
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
+      {{- end }}
       - name: httpdlog
         emptyDir: {}
       {{- range $key, $val := .Values.additionalSecrets }}


### PR DESCRIPTION
Otherwise, it will try to mount secrets which don't exist.