### PR TITLE
rucio-server: fix jinja substitution eol stripping

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.1.4
+version: 1.1.5
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
-      {{- if .Values.ftsRenewal.enabled -}}
+      {{- if .Values.ftsRenewal.enabled }}
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up


### PR DESCRIPTION
otherwise the generated yaml is invalid