### PR TITLE
Add auth,ping endpoint for auth endpoint

### DIFF
--- a/charts/rucio-server/templates/auth_deployment.yaml
+++ b/charts/rucio-server/templates/auth_deployment.yaml
@@ -159,6 +159,8 @@ spec:
 {{- end }}
             - name: RUCIO_SERVER_TYPE
               value: "{{ .Values.serverType.authServer }}"
+            - name: RUCIO_CFG_API_ENDPOINTS
+              value: "auth,ping"
             - name: RUCIO_LOG_FORMAT
               value: '{{ .Values.logFormat.authServer }}'
             - name: RUCIO_WSGI_DAEMON_PROCESSES


### PR DESCRIPTION
Since 1.26, the exposed endpoint is controlled through config. This PR adds a config item to expose `auth` and `ping` endpoint in the auth server.