### PR TITLE
daemons: rework configuration passing in conveyor

### DIFF
--- a/charts/rucio-daemons/templates/conveyor-finisher.yaml
+++ b/charts/rucio-daemons/templates/conveyor-finisher.yaml
@@ -1,4 +1,18 @@
 {{- if gt .Values.conveyorFinisherCount 0.0 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rucio.fullname" . }}.config.conveyor-finisher
+  labels:
+    app: {{ template "rucio.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  rucio.config.common.json: {{ .Values.config | default dict | mustToPrettyJson | b64enc | quote }}
+  rucio.config.component.json: {{ .Values.conveyorFinisher.config | default dict | mustToPrettyJson | b64enc | quote }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +60,9 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
+      - name: config
+        secret:
+          secretName: {{ template "rucio.fullname" . }}.config.conveyor-finisher
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -71,6 +88,12 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.common.json
+              subPath: rucio.config.common.json
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.component.json
+              subPath: rucio.config.component.json
           {{- range $key, $val := .Values.additionalSecrets }}
             - name: {{ $key }}
               mountPath: {{ $val.mountPath }}
@@ -85,6 +108,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            {{- if .Values.exportConfigToEnv }}
             {{- range $key1, $val1 := .Values.config }}
             {{- range $key2, $val2 := $val1}}
             - name: RUCIO_CFG_{{ $key1 | upper }}_{{ $key2 | upper }}
@@ -94,10 +118,13 @@ spec:
                   key: {{ $key1 }}_{{ $key2 }}
             {{- end}}
             {{- end}}
+            {{- end}}
             {{- range $key1, $val1 := .Values.optional_config }}
             - name: {{ $key1 | upper }}
               value: "{{ $val1  }}"
             {{- end}}
+            - name: RUCIO_CONFIG_OVERRIDES
+              value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
               value: "conveyor-finisher"
             - name: RUCIO_DAEMON_ARGS

--- a/charts/rucio-daemons/templates/conveyor-poller.yaml
+++ b/charts/rucio-daemons/templates/conveyor-poller.yaml
@@ -1,4 +1,18 @@
 {{- if gt .Values.conveyorPollerCount 0.0 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rucio.fullname" . }}.config.conveyor-poller
+  labels:
+    app: {{ template "rucio.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  rucio.config.common.json: {{ .Values.config | default dict | mustToPrettyJson | b64enc | quote }}
+  rucio.config.component.json: {{ .Values.conveyorPoller.config | default dict | mustToPrettyJson | b64enc | quote }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +60,9 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
+      - name: config
+        secret:
+          secretName: {{ template "rucio.fullname" . }}.config.conveyor-poller
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -71,6 +88,12 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.common.json
+              subPath: rucio.config.common.json
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.component.json
+              subPath: rucio.config.component.json
           {{- range $key, $val := .Values.additionalSecrets }}
             - name: {{ $key }}
               mountPath: {{ $val.mountPath }}
@@ -85,6 +108,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            {{- if .Values.exportConfigToEnv }}
             {{- range $key1, $val1 := .Values.config }}
             {{- range $key2, $val2 := $val1}}
             - name: RUCIO_CFG_{{ $key1 | upper }}_{{ $key2 | upper }}
@@ -100,10 +124,13 @@ spec:
               value: {{ $val2 | quote }}
             {{- end }}
             {{- end }}
+            {{- end }}
             {{- range $key1, $val1 := .Values.optional_config }}
             - name: {{ $key1 | upper }}
               value: "{{ $val1  }}"
             {{- end}}
+            - name: RUCIO_CONFIG_OVERRIDES
+              value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
               value: "conveyor-poller"
             - name: RUCIO_DAEMON_ARGS

--- a/charts/rucio-daemons/templates/conveyor-preparer.yaml
+++ b/charts/rucio-daemons/templates/conveyor-preparer.yaml
@@ -1,4 +1,18 @@
 {{- if gt .Values.conveyorPreparerCount 0.0 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rucio.fullname" . }}.config.conveyor-preparer
+  labels:
+    app: {{ template "rucio.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  rucio.config.common.json: {{ .Values.config | default dict | mustToPrettyJson | b64enc | quote }}
+  rucio.config.component.json: {{ .Values.conveyorPreparer.config | default dict | mustToPrettyJson | b64enc | quote }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +60,9 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
+      - name: config
+        secret:
+          secretName: {{ template "rucio.fullname" . }}.config.conveyor-preparer
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -71,6 +88,12 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.common.json
+              subPath: rucio.config.common.json
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.component.json
+              subPath: rucio.config.component.json
           {{- range $key, $val := .Values.additionalSecrets }}
             - name: {{ $key }}
               mountPath: {{ $val.mountPath }}
@@ -85,6 +108,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            {{- if .Values.exportConfigToEnv }}
             {{- range $key1, $val1 := .Values.config }}
             {{- range $key2, $val2 := $val1}}
             - name: RUCIO_CFG_{{ $key1 | upper }}_{{ $key2 | upper }}
@@ -94,10 +118,13 @@ spec:
                   key: {{ $key1 }}_{{ $key2 }}
             {{- end}}
             {{- end}}
+            {{- end}}
             {{- range $key1, $val1 := .Values.optional_config }}
             - name: {{ $key1 | upper }}
               value: "{{ $val1  }}"
             {{- end}}
+            - name: RUCIO_CONFIG_OVERRIDES
+              value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
               value: "conveyor-preparer"
             - name: RUCIO_DAEMON_ARGS

--- a/charts/rucio-daemons/templates/conveyor-receiver.yaml
+++ b/charts/rucio-daemons/templates/conveyor-receiver.yaml
@@ -1,4 +1,18 @@
 {{- if gt .Values.conveyorReceiverCount 0.0 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rucio.fullname" . }}.config.conveyor-receiver
+  labels:
+    app: {{ template "rucio.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  rucio.config.common.json: {{ .Values.config | default dict | mustToPrettyJson | b64enc | quote }}
+  rucio.config.component.json: {{ .Values.conveyorReceiver.config | default dict | mustToPrettyJson | b64enc | quote }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +60,9 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
+      - name: config
+        secret:
+          secretName: {{ template "rucio.fullname" . }}.config.conveyor-receiver
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -71,6 +88,12 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.common.json
+              subPath: rucio.config.common.json
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.component.json
+              subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
             - name: {{ $key }}
               mountPath: {{ $val.mountPath }}
@@ -85,6 +108,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            {{- if .Values.exportConfigToEnv }}
             {{- range $key1, $val1 := .Values.config }}
             {{- range $key2, $val2 := $val1}}
             - name: RUCIO_CFG_{{ $key1 | upper }}_{{ $key2 | upper }}
@@ -94,10 +118,13 @@ spec:
                   key: {{ $key1 }}_{{ $key2 }}
             {{- end}}
             {{- end}}
+            {{- end}}
             {{- range $key1, $val1 := .Values.optional_config }}
             - name: {{ $key1 | upper }}
               value: "{{ $val1  }}"
             {{- end}}
+            - name: RUCIO_CONFIG_OVERRIDES
+              value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
               value: "conveyor-receiver"
             - name: RUCIO_DAEMON_ARGS

--- a/charts/rucio-daemons/templates/conveyor-stager.yaml
+++ b/charts/rucio-daemons/templates/conveyor-stager.yaml
@@ -1,4 +1,18 @@
 {{- if gt .Values.conveyorStagerCount 0.0 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rucio.fullname" . }}.config.conveyor-stager
+  labels:
+    app: {{ template "rucio.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  rucio.config.common.json: {{ .Values.config | default dict | mustToPrettyJson | b64enc | quote }}
+  rucio.config.component.json: {{ .Values.conveyorStager.config | default dict | mustToPrettyJson | b64enc | quote }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,6 +48,9 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
+      - name: config
+        secret:
+          secretName: {{ template "rucio.fullname" . }}.config.conveyor-stager
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -59,6 +76,12 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.common.json
+              subPath: rucio.config.common.json
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.component.json
+              subPath: rucio.config.component.json
           {{- range $key, $val := .Values.additionalSecrets }}
             - name: {{ $key }}
               mountPath: {{ $val.mountPath }}
@@ -73,6 +96,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            {{- if .Values.exportConfigToEnv }}
             {{- range $key1, $val1 := .Values.config }}
             {{- range $key2, $val2 := $val1}}
             - name: RUCIO_CFG_{{ $key1 | upper }}_{{ $key2 | upper }}
@@ -82,10 +106,13 @@ spec:
                   key: {{ $key1 }}_{{ $key2 }}
             {{- end}}
             {{- end}}
+            {{- end}}
             {{- range $key1, $val1 := .Values.optional_config }}
             - name: {{ $key1 | upper }}
               value: "{{ $val1  }}"
             {{- end}}
+            - name: RUCIO_CONFIG_OVERRIDES
+              value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
               value: "conveyor-stager"
             - name: RUCIO_DAEMON_ARGS

--- a/charts/rucio-daemons/templates/conveyor-submitter.yaml
+++ b/charts/rucio-daemons/templates/conveyor-submitter.yaml
@@ -1,4 +1,18 @@
 {{- if gt .Values.conveyorTransferSubmitterCount 0.0 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rucio.fullname" . }}.config.conveyor-submitter
+  labels:
+    app: {{ template "rucio.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  rucio.config.common.json: {{ .Values.config | default dict | mustToPrettyJson | b64enc | quote }}
+  rucio.config.component.json: {{ .Values.conveyorTransferSubmitter.config | default dict | mustToPrettyJson | b64enc | quote }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +60,9 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
+      - name: config
+        secret:
+          secretName: {{ template "rucio.fullname" . }}.config.conveyor-submitter
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -67,6 +84,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.common.json
+              subPath: rucio.config.common.json
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.component.json
+              subPath: rucio.config.component.json
             - name: proxy-volume
               mountPath: /opt/proxy
             - name: ca-volume
@@ -85,6 +108,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            {{- if .Values.exportConfigToEnv }}
             {{- range $key1, $val1 := .Values.config }}
             {{- range $key2, $val2 := $val1}}
             - name: RUCIO_CFG_{{ $key1 | upper }}_{{ $key2 | upper }}
@@ -94,10 +118,13 @@ spec:
                   key: {{ $key1 }}_{{ $key2 }}
             {{- end}}
             {{- end}}
+            {{- end}}
             {{- range $key1, $val1 := .Values.optional_config }}
             - name: {{ $key1 | upper }}
               value: "{{ $val1  }}"
             {{- end}}
+            - name: RUCIO_CONFIG_OVERRIDES
+              value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
               value: "conveyor-submitter"
             - name: RUCIO_DAEMON_ARGS

--- a/charts/rucio-daemons/templates/conveyor-throttler.yaml
+++ b/charts/rucio-daemons/templates/conveyor-throttler.yaml
@@ -1,4 +1,18 @@
 {{- if gt .Values.conveyorThrottlerCount 0.0 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rucio.fullname" . }}.config.conveyor-throttler
+  labels:
+    app: {{ template "rucio.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  rucio.config.common.json: {{ .Values.config | default dict | mustToPrettyJson | b64enc | quote }}
+  rucio.config.component.json: {{ .Values.conveyorThrottler.config | default dict | mustToPrettyJson | b64enc | quote }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +60,9 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
     {{- end }}
       volumes:
+      - name: config
+        secret:
+          secretName: {{ template "rucio.fullname" . }}.config.conveyor-throttler
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -71,6 +88,12 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.common.json
+              subPath: rucio.config.common.json
+            - name: config
+              mountPath: /opt/rucio/etc/rucio.config.component.json
+              subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
             - name: {{ $key }}
               mountPath: {{ $val.mountPath }}
@@ -85,6 +108,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            {{- if .Values.exportConfigToEnv }}
             {{- range $key1, $val1 := .Values.config }}
             {{- range $key2, $val2 := $val1}}
             - name: RUCIO_CFG_{{ $key1 | upper }}_{{ $key2 | upper }}
@@ -94,10 +118,13 @@ spec:
                   key: {{ $key1 }}_{{ $key2 }}
             {{- end}}
             {{- end}}
+            {{- end}}
             {{- range $key1, $val1 := .Values.optional_config }}
             - name: {{ $key1 | upper }}
               value: "{{ $val1  }}"
             {{- end}}
+            - name: RUCIO_CONFIG_OVERRIDES
+              value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
               value: "conveyor-fts-throttler"
             - name: RUCIO_DAEMON_ARGS

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -41,6 +41,8 @@ strategy:
     maxSurge: 1
     maxUnavailable: 1
 
+exportConfigToEnv: true
+
 podLabels: {}
 podAnnotations: {}
 


### PR DESCRIPTION
Each daemon will now have its own config secret with two sections: "common" and
"component". The common is the same for all daemons. I initially thought about having
a separate "common" kube secret shared among all daemons, but changed my mind.
I consider that having two secrets makes the configuration flow more complex while
the benefit (no duplication) is small.

As long as values.exportConfigToEnv==True, the change must not impact existing
deployments. The new secrets will be generated in kube, mounter into containers,
but not used by rucio.
The associated change in rucio/containers must be integrated into containers before
setting this variable to False.

If the new behavior is accepted, all daemons and servers will have to be updated.
I also vote for breaking the reverse compatibility in 1.27 and remove
code exporting the config as env variables.