### PR TITLE
servers: support both subPath and subPaths in additionalSecrets. Closes #70

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.26.1
+version: 1.26.2
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/auth_deployment.yaml
+++ b/charts/rucio-server/templates/auth_deployment.yaml
@@ -106,11 +106,18 @@ spec:
             - name: httpdlog
               mountPath: /var/log/httpd
             {{- range $key, $val := .Values.additionalSecrets }}
-            {{- range $val.subPaths }}
+            {{- /* TODO: depreacte and remove support for subPaths (at plural) case */}}
+            {{-  if $val.subPaths }}
+            {{-   range $val.subPaths }}
             - name: {{ $key }}
               mountPath: {{ $val.mountPath }}{{ . }}
               subPath: {{ . }}
-            {{- end}}
+            {{-   end}}
+            {{-  else }}
+            - name: {{ $key }}
+              mountPath: {{ $val.mountPath }}
+              subPath: {{ $val.subPath }}
+            {{-  end}}
             {{- end}}
             {{- range $key, $val := .Values.persistentVolumes }}
             - name: {{ $key }}

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -105,11 +105,18 @@ spec:
           - name: httpdlog
             mountPath: /var/log/httpd
           {{- range $key, $val := .Values.additionalSecrets }}
-          {{- range $val.subPaths }}
+          {{- /* TODO: depreacte and remove support for subPaths (at plural) case */}}
+          {{-  if $val.subPaths }}
+          {{-   range $val.subPaths }}
           - name: {{ $key }}
             mountPath: {{ $val.mountPath }}{{ . }}
             subPath: {{ . }}
-          {{- end}}
+          {{-   end}}
+          {{-  else }}
+          - name: {{ $key }}
+            mountPath: {{ $val.mountPath }}
+            subPath: {{ $val.subPath }}
+          {{-  end}}
           {{- end}}
           {{- range $key, $val := .Values.persistentVolumes }}
           - name: {{ $key }}

--- a/charts/rucio-server/templates/trace_deployment.yaml
+++ b/charts/rucio-server/templates/trace_deployment.yaml
@@ -111,11 +111,18 @@ spec:
               mountPath: /etc/grid-security/ca.pem
               subPath: ca.pem
             {{- range $key, $val := .Values.additionalSecrets }}
-            {{- range $val.subPaths }}
+            {{- /* TODO: depreacte and remove support for subPaths (at plural) case */}}
+            {{-  if $val.subPaths }}
+            {{-   range $val.subPaths }}
             - name: {{ $key }}
               mountPath: {{ $val.mountPath }}{{ . }}
               subPath: {{ . }}
-            {{- end}}
+            {{-   end}}
+            {{-  else }}
+            - name: {{ $key }}
+              mountPath: {{ $val.mountPath }}
+              subPath: {{ $val.subPath }}
+            {{-  end}}
             {{- end}}
 {{- end }}
           env:


### PR DESCRIPTION
It is inconsistency with unknown origin. Other helm-charts only allow
usage of supPath (singular), but servers only allow it at plural.
Also, subPaths is not documented anywhere. Even the server chart
documentation shows the singular form.

For a transitory period, allow usage of both forms, but I suggest to
completely remove support for the plural form latter.