### PR TITLE
servers: expose and collect server prometheus metrics

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.27.1
+version: 1.27.2
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/auth_deployment.yaml
+++ b/charts/rucio-server/templates/auth_deployment.yaml
@@ -109,6 +109,11 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
+{{- if .Values.monitoring.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.monitoring.nativeMetricsPort }}
+              protocol: TCP
+{{- end }}
           livenessProbe:
             httpGet:
               path: /ping
@@ -187,6 +192,10 @@ spec:
 {{- else }}
             - name: RUCIO_ENABLE_SSL
               value: "False"
+{{- end }}
+{{- if .Values.monitoring.enabled }}
+            - name: RUCIO_METRICS_PORT
+              value: "{{ .Values.monitoring.nativeMetricsPort }}"
 {{- end }}
             - name: RUCIO_SERVER_TYPE
               value: "{{ .Values.serverType.authServer }}"

--- a/charts/rucio-server/templates/auth_servicemonitor.yaml
+++ b/charts/rucio-server/templates/auth_servicemonitor.yaml
@@ -20,6 +20,11 @@ spec:
  {{- if .Values.monitoring.telemetryPath }}
     path: {{ .Values.monitoring.telemetryPath }}
  {{- end }}
+  - targetPort: {{ .Values.monitoring.nativeMetricsPort }}
+ {{- if .Values.monitoring.interval }}
+    interval: {{ .Values.monitoring.interval }}
+ {{- end }}
+    path: /metrics/
   jobLabel: {{ template "rucio.fullname" . }}-prometheus-exporter-auth
   namespaceSelector:
     matchNames:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -162,6 +162,11 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
+{{- if .Values.monitoring.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.monitoring.nativeMetricsPort }}
+              protocol: TCP
+{{- end }}
           livenessProbe:
             httpGet:
               path: /ping
@@ -205,6 +210,10 @@ spec:
 {{- else }}
             - name: RUCIO_ENABLE_SSL
               value: "False"
+{{- end }}
+{{- if .Values.monitoring.enabled }}
+            - name: RUCIO_METRICS_PORT
+              value: "{{ .Values.monitoring.nativeMetricsPort }}"
 {{- end }}
             - name: RUCIO_SERVER_TYPE
               value: "{{ .Values.serverType.server }}"

--- a/charts/rucio-server/templates/servicemonitor.yaml
+++ b/charts/rucio-server/templates/servicemonitor.yaml
@@ -20,6 +20,11 @@ spec:
  {{- if .Values.monitoring.telemetryPath }}
     path: {{ .Values.monitoring.telemetryPath }}
  {{- end }}
+  - targetPort: {{ .Values.monitoring.nativeMetricsPort }}
+ {{- if .Values.monitoring.interval }}
+    interval: {{ .Values.monitoring.interval }}
+ {{- end }}
+    path: /metrics/
   jobLabel: {{ template "rucio.fullname" . }}-prometheus-exporter
   namespaceSelector:
     matchNames:

--- a/charts/rucio-server/templates/trace_deployment.yaml
+++ b/charts/rucio-server/templates/trace_deployment.yaml
@@ -104,6 +104,11 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
+{{- if .Values.monitoring.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.monitoring.nativeMetricsPort }}
+              protocol: TCP
+{{- end }}
           livenessProbe:
             httpGet:
               path: /ping
@@ -174,6 +179,10 @@ spec:
 {{- else }}
             - name: RUCIO_ENABLE_SSL
               value: "False"
+{{- end }}
+{{- if .Values.monitoring.enabled }}
+            - name: RUCIO_METRICS_PORT
+              value: "{{ .Values.monitoring.nativeMetricsPort }}"
 {{- end }}
             - name: RUCIO_SERVER_TYPE
               value: "{{ .Values.serverType.traceServer }}"

--- a/charts/rucio-server/templates/trace_servicemonitor.yaml
+++ b/charts/rucio-server/templates/trace_servicemonitor.yaml
@@ -20,6 +20,11 @@ spec:
  {{- if .Values.monitoring.telemetryPath }}
     path: {{ .Values.monitoring.telemetryPath }}
  {{- end }}
+  - targetPort: {{ .Values.monitoring.nativeMetricsPort }}
+ {{- if .Values.monitoring.interval }}
+    interval: {{ .Values.monitoring.interval }}
+ {{- end }}
+    path: /metrics/
   jobLabel: {{ template "rucio.fullname" . }}-prometheus-exporter-trace
   namespaceSelector:
     matchNames:

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -101,6 +101,7 @@ monitoring:
   enabled: false
   exporterPort: 8080
   targetPort: 8080
+  nativeMetricsPort: 8081
   interval: 30s
   telemetryPath: /metrics
   namespace: monitoring


### PR DESCRIPTION
Latest containers are now built with the possibility to export
prometheus metrics on a separate port:
https://github.com/rucio/containers/pull/180

This PR ensures that the correct ENV variable is set to trigger
this behavior in servers and that the prometheus-operator
ServiceMonitor CRD is configured to automatically scrape that
endpoint.