### PR TITLE
servers & ui: support kube 1.22+ in ingress. Closes #80

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.27.2
+version: 1.27.3
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/_helpers.tpl
+++ b/charts/rucio-server/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "rucio.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Get Ingress Kube API Version
+*/}}
+{{- define "rucio.ingress.apiVersion" -}}
+  {{- if semverCompare ">= 1.19.x" (default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride) -}}
+    {{- print "networking.k8s.io/v1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/rucio-server/templates/auth_ingress.yaml
+++ b/charts/rucio-server/templates/auth_ingress.yaml
@@ -2,7 +2,8 @@
 {{- if .Values.authIngress.enabled -}}
 {{- $fullName := include "rucio.fullname" . -}}
 {{- $ingressPath := .Values.authIngress.path -}}
-apiVersion: extensions/v1beta1
+{{- $kubeApiVersion := include "rucio.ingress.apiVersion" . -}}
+apiVersion: {{ $kubeApiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}-auth
@@ -33,8 +34,16 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
+    {{- if eq $kubeApiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}-auth
+                port:
+                  number: {{ $.Values.authService.port }}
+            pathType: Prefix
+    {{- else }}
               serviceName: {{ $fullName }}-auth
               servicePort: {{ $.Values.authService.port }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rucio-server/templates/ingress.yaml
+++ b/charts/rucio-server/templates/ingress.yaml
@@ -2,7 +2,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rucio.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+{{- $kubeApiVersion := include "rucio.ingress.apiVersion" . -}}
+apiVersion: {{ $kubeApiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,8 +34,16 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
+    {{- if eq $kubeApiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $.Values.service.port }}
+            pathType: Prefix
+    {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $.Values.service.port }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rucio-server/templates/trace_ingress.yaml
+++ b/charts/rucio-server/templates/trace_ingress.yaml
@@ -2,7 +2,8 @@
 {{- if .Values.traceIngress.enabled -}}
 {{- $fullName := include "rucio.fullname" . -}}
 {{- $ingressPath := .Values.traceIngress.path -}}
-apiVersion: extensions/v1beta1
+{{- $kubeApiVersion := include "rucio.ingress.apiVersion" . -}}
+apiVersion: {{ $kubeApiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}-trace
@@ -33,8 +34,16 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
+    {{- if eq $kubeApiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}-trace
+                port:
+                  number: {{ $.Values.traceService.port }}
+            pathType: Prefix
+    {{- else }}
               serviceName: {{ $fullName }}-trace
               servicePort: {{ $.Values.traceService.port }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 1.27.0
+version: 1.27.1
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/_helpers.tpl
+++ b/charts/rucio-ui/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "rucio.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Get Ingress Kube API Version
+*/}}
+{{- define "rucio.ingress.apiVersion" -}}
+  {{- if semverCompare ">= 1.19.x" (default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride) -}}
+    {{- print "networking.k8s.io/v1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/rucio-ui/templates/ingress.yaml
+++ b/charts/rucio-ui/templates/ingress.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rucio.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+{{- $kubeApiVersion := include "rucio.ingress.apiVersion" . -}}
+apiVersion: {{ $kubeApiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -22,7 +23,15 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
+    {{- if eq $kubeApiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $.Values.service.port }}
+            pathType: Prefix
+    {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $.Values.service.port }}
+    {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The stable ingress api is available since kubernetes 1.19 (August 26, 2020).
The old beta api is deprecated in 1.22.