### PR TITLE
Fix references to incorrect host values for Ingresses. Closes #92

### DIFF
--- a/charts/rucio-server/templates/auth_ingress.yaml
+++ b/charts/rucio-server/templates/auth_ingress.yaml
@@ -20,7 +20,7 @@ spec:
   tls:
   {{- range .Values.authIngress.tls }}
     - hosts:
-      {{- range $.Values.ingress.hosts }}
+      {{- range $.Values.authIngress.hosts }}
         - {{ . }}
       {{- end }}
       secretName: {{ .secretName }}

--- a/charts/rucio-server/templates/trace_ingress.yaml
+++ b/charts/rucio-server/templates/trace_ingress.yaml
@@ -20,7 +20,7 @@ spec:
   tls:
   {{- range .Values.traceIngress.tls }}
     - hosts:
-      {{- range $.Values.ingress.hosts }}
+      {{- range $.Values.traceIngress.hosts }}
         - {{ . }}
       {{- end }}
       secretName: {{ .secretName }}


### PR DESCRIPTION
Also add the changes back to 1.26 for me. :)