### PR TITLE
Variable for Legacy DN format

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.28.2
+version: 1.28.3
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -146,6 +146,7 @@ wsgi:
 httpd_config:
   mpm_mode: "event"
   enable_status: "True"
+  legacy_dn: "False"
   # keep_alive: "On"
   # keep_alive_timeout: "5"
   # max_keep_alive_requests: "128"


### PR DESCRIPTION
Add a variable for the legacy DN format. With a change to the containers, this could be back ported to LTS releases if needed