### PR TITLE
Add resource requests for CronJobs

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.29.2
+version: 1.29.3
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/auth_deployment.yaml
+++ b/charts/rucio-server/templates/auth_deployment.yaml
@@ -83,6 +83,8 @@ spec:
           volumeMounts:
           - name: httpdlog
             mountPath: /var/log/httpd
+          resources:
+{{ toYaml .Values.errorLogsExporterResources | indent 12 }}            
 {{- end }}
 {{- if .Values.monitoring.enabled }}
         - name: apache-exporter

--- a/charts/rucio-server/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-server/templates/automatic-restart-cronjob.yaml
@@ -16,6 +16,6 @@ spec:
               imagePullPolicy: {{ .Values.automaticRestart.image.pullPolicy }}
               command: ["/bin/sh", "-c", "kubectl get deployment -l {{ .Values.automaticRestart.selectorLabel }} -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | xargs -n 1 kubectl rollout restart deployment"]
               resources:
-{{ toYaml .Values.automaticRestartResources | indent 15 }}
+{{ toYaml .Values.automaticRestart | indent 15 }}
           restartPolicy: OnFailure
 {{ end }}

--- a/charts/rucio-server/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-server/templates/automatic-restart-cronjob.yaml
@@ -15,5 +15,7 @@ spec:
               image: "{{ .Values.automaticRestart.image.repository }}:{{ .Values.automaticRestart.image.tag }}"
               imagePullPolicy: {{ .Values.automaticRestart.image.pullPolicy }}
               command: ["/bin/sh", "-c", "kubectl get deployment -l {{ .Values.automaticRestart.selectorLabel }} -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | xargs -n 1 kubectl rollout restart deployment"]
+              resources:
+{{ toYaml .Values.automaticRestartResources | indent 15 }}
           restartPolicy: OnFailure
 {{ end }}

--- a/charts/rucio-server/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-server/templates/automatic-restart-cronjob.yaml
@@ -16,6 +16,6 @@ spec:
               imagePullPolicy: {{ .Values.automaticRestart.image.pullPolicy }}
               command: ["/bin/sh", "-c", "kubectl get deployment -l {{ .Values.automaticRestart.selectorLabel }} -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | xargs -n 1 kubectl rollout restart deployment"]
               resources:
-{{ toYaml .Values.automaticRestart | indent 15 }}
+{{ toYaml .Values.automaticRestart.resources | indent 15 }}
           restartPolicy: OnFailure
 {{ end }}

--- a/charts/rucio-server/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-server/templates/renew-fts-cronjob.yaml
@@ -24,7 +24,7 @@
       image: "{{ .Values.ftsRenewal.image.repository }}:{{ .Values.ftsRenewal.image.tag }}"
       imagePullPolicy: {{ .Values.ftsRenewal.image.pullPolicy }}
       resources:
-{{ toYaml .Values.ftsRenewalResources | indent 15 }}
+{{ toYaml .Values.ftsRenewal | indent 15 }}
       volumeMounts:
   {{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
         - name: longproxy

--- a/charts/rucio-server/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-server/templates/renew-fts-cronjob.yaml
@@ -23,6 +23,8 @@
     - name: renew-fts-cron
       image: "{{ .Values.ftsRenewal.image.repository }}:{{ .Values.ftsRenewal.image.tag }}"
       imagePullPolicy: {{ .Values.ftsRenewal.image.pullPolicy }}
+      resources:
+{{ toYaml .Values.ftsRenewalResources | indent 15 }}
       volumeMounts:
   {{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
         - name: longproxy

--- a/charts/rucio-server/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-server/templates/renew-fts-cronjob.yaml
@@ -24,7 +24,7 @@
       image: "{{ .Values.ftsRenewal.image.repository }}:{{ .Values.ftsRenewal.image.tag }}"
       imagePullPolicy: {{ .Values.ftsRenewal.image.pullPolicy }}
       resources:
-{{ toYaml .Values.ftsRenewal | indent 15 }}
+{{ toYaml .Values.ftsRenewal.resources | indent 15 }}
       volumeMounts:
   {{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
         - name: longproxy

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -124,8 +124,6 @@ ftsRenewal:
   vo: "cms"
   voms: "cms:/cms/Role=production"
   servers: "https://fts3-devel.cern.ch:8446,https://cmsfts3.fnal.gov:8446,https://fts3.cern.ch:8446,https://lcgfts3.gridpp.rl.ac.uk:8446,https://fts3-pilot.cern.ch:8446"
-
-ftsRenewalResources:
   limits:
     cpu: 500m
     memory: 256Mi
@@ -141,14 +139,13 @@ automaticRestart:
     pullPolicy: IfNotPresent
   schedule: "0 0 * * *"
   selectorLabel: "'app in (rucio-server,rucio-server-trace,rucio-server-auth)'"
-
-automaticRestartResources:
-  limits:
-   cpu: 500m
-   memory: 256Mi
-  requests:
-   cpu: 100m
-   memory: 128Mi
+  resources:
+    limits:
+     cpu: 500m
+     memory: 256Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
 additionalSecrets: {}
   # gcssecret:

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -125,6 +125,14 @@ ftsRenewal:
   voms: "cms:/cms/Role=production"
   servers: "https://fts3-devel.cern.ch:8446,https://cmsfts3.fnal.gov:8446,https://fts3.cern.ch:8446,https://lcgfts3.gridpp.rl.ac.uk:8446,https://fts3-pilot.cern.ch:8446"
 
+ftsRenewalResources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
 automaticRestart:
   enabled: 0
   image:
@@ -133,6 +141,14 @@ automaticRestart:
     pullPolicy: IfNotPresent
   schedule: "0 0 * * *"
   selectorLabel: "'app in (rucio-server,rucio-server-trace,rucio-server-auth)'"
+
+automaticRestartResources:
+  limits:
+   cpu: 500m
+   memory: 256Mi
+  requests:
+   cpu: 100m
+   memory: 128Mi
 
 additionalSecrets: {}
   # gcssecret:

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -124,12 +124,13 @@ ftsRenewal:
   vo: "cms"
   voms: "cms:/cms/Role=production"
   servers: "https://fts3-devel.cern.ch:8446,https://cmsfts3.fnal.gov:8446,https://fts3.cern.ch:8446,https://lcgfts3.gridpp.rl.ac.uk:8446,https://fts3-pilot.cern.ch:8446"
-  limits:
-    cpu: 500m
-    memory: 256Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 automaticRestart:
   enabled: 0


### PR DESCRIPTION
Some resources (namely, [NRP](https://dash.nrp-nautilus.io/) ) have strict requirements for all containers to explicitly request resources.

This PR adds resource requests for the FTS renewal and server restart cronjobs.  It also adds a resource request for the error exporter in the authentication server.