### PR TITLE
daemons: rework the app label

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 1.29.0
+version: 1.29.1
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/abacus-account.yaml
+++ b/charts/rucio-daemons/templates/abacus-account.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.abacusAccountCount 0.0 -}}
+{{- $rucio_daemon := "abacus-account" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.abacus-account.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-abacus-account
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.abacusAccountCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: abacus-account
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.abacus-account.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -112,7 +116,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "abacus-account"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "--threads {{ .Values.abacusAccount.threads }}"
 {{- with .Values.abacusAccount.resources }}

--- a/charts/rucio-daemons/templates/abacus-collection-replica.yaml
+++ b/charts/rucio-daemons/templates/abacus-collection-replica.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.abacusCollectionReplicaCount 0.0 -}}
+{{- $rucio_daemon := "abacus-collection-replica" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.abacus-collection-replica.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-abacus-collection-replica
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.abacusCollectionReplicaCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: abacus-collection-replica
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.abacus-collection-replica.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -112,7 +116,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "abacus-collection-replica"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "--threads {{ .Values.abacusCollectionReplica.threads }}"
 {{- with .Values.abacusCollectionReplica.resources }}

--- a/charts/rucio-daemons/templates/abacus-rse.yaml
+++ b/charts/rucio-daemons/templates/abacus-rse.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.abacusRseCount 0.0 -}}
+{{- $rucio_daemon := "abacus-rse" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.abacus-rse.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-abacus-rse
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.abacusRseCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: abacus-rse
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.abacus-rse.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -112,7 +116,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "abacus-rse"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.abacusRse.fillHistoryTable }}--enable-history {{ end }}--threads {{ .Values.abacusRse.threads }}"
 {{- with .Values.abacusRse.resources }}

--- a/charts/rucio-daemons/templates/automatix.yaml
+++ b/charts/rucio-daemons/templates/automatix.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.automatixCount 0.0 -}}
+{{- $rucio_daemon := "automatix" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.automatix.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-automatix
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.automatixCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: automatix
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.automatix.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -121,7 +125,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "automatix"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.automatix.threads }} --threads-per-process {{ .Values.automatix.threads }}{{ end }} {{- if .Values.automatix.inputFile }} --input-file {{ .Values.automatix.inputFile }}{{ end }} {{- if .Values.automatix.sleepTime }} --sleep-time {{ .Values.automatix.sleepTime }}{{ end }}"
             - name: X509_USER_PROXY

--- a/charts/rucio-daemons/templates/cache-consumer.yaml
+++ b/charts/rucio-daemons/templates/cache-consumer.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.cacheConsumerCount 0.0 -}}
+{{- $rucio_daemon := "cache-consumer" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.cache-consumer
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-cache-consumer
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.cacheConsumerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: cache-consumer
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.cache-consumer
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
       {{- range $key, $val := .Values.additionalSecrets }}
       - name: {{ $key }}
         secret:
@@ -106,7 +110,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "cache-consumer"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.cacheConsumer.threads }} --num-thread {{ .Values.cacheConsumer.threads }} {{ end }}"
 {{- with .Values.cacheConsumer.resources }}

--- a/charts/rucio-daemons/templates/conveyor-finisher.yaml
+++ b/charts/rucio-daemons/templates/conveyor-finisher.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.conveyorFinisherCount 0.0 -}}
+{{- $rucio_daemon := "conveyor-finisher" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.conveyor-finisher
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-conveyor-finisher
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.conveyorFinisherCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: conveyor-finisher
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.conveyor-finisher
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "conveyor-finisher"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.conveyorFinisher.threads }} --total-threads {{ .Values.conveyorFinisher.threads }}{{ end }} {{- if .Values.conveyorFinisher.dbBulk }} --db-bulk {{ .Values.conveyorFinisher.dbBulk }}{{ end }} {{- if .Values.conveyorFinisher.bulk }} --bulk {{ .Values.conveyorFinisher.bulk }}{{ end }} {{- if .Values.conveyorFinisher.sleepTime }} --sleep-time {{ .Values.conveyorFinisher.sleepTime }}{{ end }} {{- if .Values.conveyorFinisher.activities }} --activities {{ .Values.conveyorFinisher.activities }}{{ end }}"
 {{- with .Values.conveyorFinisher.resources }}

--- a/charts/rucio-daemons/templates/conveyor-poller.yaml
+++ b/charts/rucio-daemons/templates/conveyor-poller.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.conveyorPollerCount 0.0 -}}
+{{- $rucio_daemon := "conveyor-poller" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.conveyor-poller
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-conveyor-poller
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.conveyorPollerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: conveyor-poller
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.conveyor-poller
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "conveyor-poller"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.conveyorPoller.threads }} --total-threads {{ .Values.conveyorPoller.threads }}{{ end }} {{ if .Values.conveyorPoller.dbBulk }} --db-bulk {{ .Values.conveyorPoller.dbBulk }}{{ end }} {{- if .Values.conveyorPoller.ftsBulk }} --fts-bulk {{ .Values.conveyorPoller.ftsBulk }}{{ end }} {{- if .Values.conveyorPoller.sleepTime }} --sleep-time {{ .Values.conveyorPoller.sleepTime }}{{ end }} {{- if .Values.conveyorPoller.activities }} --activities {{ .Values.conveyorPoller.activities }}{{ end }} {{- if .Values.conveyorPoller.olderThan }} --older-than {{ .Values.conveyorPoller.olderThan }}{{ end }} {{- if .Values.conveyorPoller.activitiesShare }} --activities-share {{ .Values.conveyorPoller.activitiesShare }}{{ end }}"
 {{- with .Values.conveyorPoller.resources }}

--- a/charts/rucio-daemons/templates/conveyor-preparer.yaml
+++ b/charts/rucio-daemons/templates/conveyor-preparer.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.conveyorPreparerCount 0.0 -}}
+{{- $rucio_daemon := "conveyor-preparer" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.conveyor-preparer
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-conveyor-preparer
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.conveyorPreparerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: conveyor-preparer
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.conveyor-preparer
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "conveyor-preparer"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.conveyorPreparer.threads }} --threads {{ .Values.conveyorPreparer.threads }}{{ end }} {{ if .Values.conveyorPreparer.bulk }} --bulk {{ .Values.conveyorPreparer.bulk }}{{ end }} {{- if .Values.conveyorPreparer.sleepTime }} --sleep-time {{ .Values.conveyorPreparer.sleepTime }}{{ end }}"
 {{- with .Values.conveyorPreparer.resources }}

--- a/charts/rucio-daemons/templates/conveyor-receiver.yaml
+++ b/charts/rucio-daemons/templates/conveyor-receiver.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.conveyorReceiverCount 0.0 -}}
+{{- $rucio_daemon := "conveyor-receiver" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.conveyor-receiver
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-conveyor-receiver
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.conveyorReceiverCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: conveyor-receiver
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.conveyor-receiver
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "conveyor-receiver"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.conveyorReceiver.threads }} --total-threads {{ .Values.conveyorReceiver.threads }}{{ end }} {{- if .Values.conveyorReceiver.fullMode }} --full-mode{{ end }}"
 {{- with .Values.conveyorReceiver.resources }}

--- a/charts/rucio-daemons/templates/conveyor-stager.yaml
+++ b/charts/rucio-daemons/templates/conveyor-stager.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.conveyorStagerCount 0.0 -}}
+{{- $rucio_daemon := "conveyor-stager" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.conveyor-stager
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-conveyor-stager
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.conveyorStagerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: conveyor-stager
+        rucio-daemon: {{ $rucio_daemon }}
       annotations:
         checksum/config: {{ print "%s%s" $common_config $component_config | sha1sum }}
     spec:
@@ -54,7 +58,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.conveyor-stager
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -107,7 +111,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "conveyor-stager"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.conveyorStager.threads }} --total-threads {{ .Values.conveyorStager.threads }}{{ end }} {{- if .Values.conveyorStager.bulk }} --bulk {{ .Values.conveyorStager.bulk }}{{ end }} {{- if .Values.conveyorStager.bulk }} --bulk {{ .Values.conveyorStager.bulk }}{{ end }} {{- if .Values.conveyorStager.sleepTime }} --sleep-time {{ .Values.conveyorStager.sleepTime }}{{ end }} {{- if .Values.conveyorStager.activities }} --activities {{ .Values.conveyorStager.activities }}{{ end }}"
 {{- with .Values.conveyorStager.resources }}

--- a/charts/rucio-daemons/templates/conveyor-submitter.yaml
+++ b/charts/rucio-daemons/templates/conveyor-submitter.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.conveyorTransferSubmitterCount 0.0 -}}
+{{- $rucio_daemon := "conveyor-submitter" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.conveyor-submitter
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-conveyor-submitter
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.conveyorTransferSubmitterCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: conveyor-submitter
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.conveyor-submitter
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "conveyor-submitter"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.conveyorTransferSubmitter.threads }} --total-threads {{ .Values.conveyorTransferSubmitter.threads }}{{ end }} {{- if .Values.conveyorTransferSubmitter.bulk }} --bulk {{ .Values.conveyorTransferSubmitter.bulk }}{{ end }} {{- if .Values.conveyorTransferSubmitter.groupBulk }} --group-bulk {{ .Values.conveyorTransferSubmitter.groupBulk }}{{ end}}{{- if .Values.conveyorTransferSubmitter.groupPolicy }} --group-policy {{ .Values.conveyorTransferSubmitter.groupPolicy }}{{ end }} {{- if .Values.conveyorTransferSubmitter.mock }} --mock {{ .Values.conveyorTransferSubmitter.mock }}{{ end }} {{- if .Values.conveyorTransferSubmitter.sourceStrategy }} --source-strategy {{ .Values.conveyorTransferSubmitter.sourceStrategy }}{{ end }} {{- if .Values.conveyorTransferSubmitter.excludeRses }} --exclude-rses {{ .Values.conveyorTransferSubmitter.excludeRses }}{{ end}} {{- if .Values.conveyorTransferSubmitter.includeRses }} --include-rses {{ .Values.conveyorTransferSubmitter.includeRses }}{{ end}} {{- if .Values.conveyorTransferSubmitter.rses }} --rses {{ .Values.conveyorTransferSubmitter.rses }}{{ end}} {{- if .Values.conveyorTransferSubmitter.sleepTime }} --sleep-time {{ .Values.conveyorTransferSubmitter.sleepTime }}{{ end}} {{- if .Values.conveyorTransferSubmitter.activities }} --activities {{ .Values.conveyorTransferSubmitter.activities }}{{ end}} {{- if .Values.conveyorTransferSubmitter.excludeActivities }} --exclude-activities {{ .Values.conveyorTransferSubmitter.excludeActivities }}{{ end}} {{- if .Values.conveyorTransferSubmitter.maxSources }} --max-sources {{ .Values.conveyorTransferSubmitter.maxSources }}{{end }} {{- if .Values.conveyorTransferSubmitter.ignoreAvailability }} --ignore-availability {{ end }} {{- if .Values.conveyorTransferSubmitter.retryOtherFts }} --retry-other-fts {{ end}} {{- if kindIs "float64" .Values.conveyorTransferSubmitter.archiveTimeout }}  --archive-timeout-override {{ .Values.conveyorTransferSubmitter.archiveTimeout }}{{ end}}"
 {{- with .Values.conveyorTransferSubmitter.resources }}

--- a/charts/rucio-daemons/templates/conveyor-throttler.yaml
+++ b/charts/rucio-daemons/templates/conveyor-throttler.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.conveyorThrottlerCount 0.0 -}}
+{{- $rucio_daemon := "conveyor-throttler" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.conveyor-throttler
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-conveyor-throttler
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.conveyorThrottlerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: conveyor-throttler
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.conveyor-throttler
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "conveyor-throttler"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.conveyorThrottler.sleepTime }} --sleep-time {{ .Values.conveyorThrottler.sleepTime }}{{ end }}"
 {{- with .Values.conveyorThrottler.resources }}

--- a/charts/rucio-daemons/templates/dark-reaper.yaml
+++ b/charts/rucio-daemons/templates/dark-reaper.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.darkReaperCount 0.0 -}}
+{{- $rucio_daemon := "dark-reaper" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.dark-reaper.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-dark-reaper
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.darkReaperCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: dark-reaper
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.dark-reaper.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "dark-reaper"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: '{{- if .Values.darkReaper.workers }} --total-workers {{ .Values.darkReaper.workers }}{{end}} {{- if .Values.darkReaper.scheme }} --scheme {{ .Values.darkReaper.scheme }}{{ end }} {{- if .Values.darkReaper.includeRses }} --include-rses="{{ .Values.darkReaper.includeRses }}"{{ end }} {{- if .Values.darkReaper.rses }} --rses {{ .Values.darkReaper.rses }}{{ end }} {{- if .Values.darkReaper.chunkSize }}  --chunk-size {{ .Values.darkReaper.chunkSize }}{{ end }} {{- if .Values.darkReaper.excludeRses }} --exclude-rses {{ .Values.darkReaper.excludeRses }}{{ end }}'
             - name: GLOBUS_THREAD_MODEL

--- a/charts/rucio-daemons/templates/hermes.yaml
+++ b/charts/rucio-daemons/templates/hermes.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.hermesCount 0.0 -}}
+{{- $rucio_daemon := "hermes" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.hermes.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-hermes
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.hermesCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: hermes
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: {{ template "rucio.fullname" . }}.config.hermes.yaml
+            secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
 {{ if .Values.hermes.useSSL }}
         - name: usercert
           secret:
@@ -120,7 +124,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "hermes"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.hermes.threads }} --threads {{ .Values.hermes.threads }}{{ end }} {{- if .Values.hermes.bulk }} --bulk {{ .Values.hermes.bulk }}{{ end }} {{- if .Values.hermes.delay }} --delay {{ .Values.hermes.delay }}{{ end }} {{- if .Values.hermes.brokerTimeout }} --broker-timeout {{ .Values.hermes.brokerTimeout }}{{ end }} {{- if .Values.hermes.brokerRetry }} --broker-retry {{ .Values.hermes.brokerRetry }}{{ end }}"
 {{- with .Values.hermes.resources }}

--- a/charts/rucio-daemons/templates/hermes2.yaml
+++ b/charts/rucio-daemons/templates/hermes2.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.hermes2Count 0.0 -}}
+{{- $rucio_daemon := "hermes2" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "rucio.fullname" . }}.config.hermes2.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-hermes2
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.hermes2Count }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: hermes2
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -120,7 +124,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "hermes2"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.hermes2.threads }} --threads {{ .Values.hermes2.threads }}{{ end }} {{ if .Values.hermes2.bulk }} --bulk {{ .Values.hermes2.bulk }}{{ end }}"
 {{- with .Values.hermes2.resources }}

--- a/charts/rucio-daemons/templates/judge-cleaner.yaml
+++ b/charts/rucio-daemons/templates/judge-cleaner.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.judgeCleanerCount 0.0 -}}
+{{- $rucio_daemon := "judge-cleaner" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.judge-cleaner.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-judge-cleaner
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.judgeCleanerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: judge-cleaner
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.judge-cleaner.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "judge-cleaner"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "--threads {{ .Values.judgeCleaner.threads }}"
 {{- with .Values.judgeCleaner.resources }}

--- a/charts/rucio-daemons/templates/judge-evaluator.yaml
+++ b/charts/rucio-daemons/templates/judge-evaluator.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.judgeEvaluatorCount 0.0 -}}
+{{- $rucio_daemon := "judge-evaluator" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.judge-evaluator.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-judge-evaluator
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.judgeEvaluatorCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: judge-evaluator
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.judge-evaluator.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "judge-evaluator"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "--threads {{ .Values.judgeEvaluator.threads }} {{- if .Values.judgeEvaluator.sleepTime }} --sleep-time {{ .Values.judgeEvaluator.sleepTime }}{{ end }} {{- if .Values.judgeEvaluator.didLimit }} --did-limit {{ .Values.judgeEvaluator.didLimit }}{{ end }}"
 {{- with .Values.judgeEvaluator.resources }}

--- a/charts/rucio-daemons/templates/judge-injector.yaml
+++ b/charts/rucio-daemons/templates/judge-injector.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.judgeInjectorCount 0.0 -}}
+{{- $rucio_daemon := "judge-injector" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.judge-injector.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-judge-injector
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.judgeInjectorCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: judge-injector
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.judge-injector.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "judge-injector"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "--threads {{ .Values.judgeInjector.threads }}"
 {{- with .Values.judgeInjector.resources }}

--- a/charts/rucio-daemons/templates/judge-repairer.yaml
+++ b/charts/rucio-daemons/templates/judge-repairer.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.judgeRepairerCount 0.0 -}}
+{{- $rucio_daemon := "judge-repairer" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.judge-repairer.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-judge-repairer
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.judgeRepairerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: judge-repairer
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.judge-repairer.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "judge-repairer"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "--threads {{ .Values.judgeRepairer.threads }}"
 {{- with .Values.judgeRepairer.resources }}

--- a/charts/rucio-daemons/templates/minos-temporary-expiration.yaml
+++ b/charts/rucio-daemons/templates/minos-temporary-expiration.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.minosTemporaryExpirationCount 0.0 -}}
+{{- $rucio_daemon := "minos-temporary-expiration" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.minos-temporary-expiration.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-minos-temporary-expiration
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.minosTemporaryExpirationCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: minos-temporary-expiration
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.minos-temporary-expiration.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "minos-temporary-expiration"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.minosTemporaryExpiration.threads }} --threads {{ .Values.minosTemporaryExpiration.threads }}{{ end }} {{- if .Values.minosTemporaryExpiration.bulk }} --bulk {{ .Values.minosTemporaryExpiration.bulk }}{{ end }} {{- if .Values.minosTemporaryExpiration.sleepTime }} --sleep-time {{ .Values.minosTemporaryExpiration.sleepTime }}{{ end}}"
 {{- with .Values.minosTemporaryExpiration.resources }}

--- a/charts/rucio-daemons/templates/minos.yaml
+++ b/charts/rucio-daemons/templates/minos.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.minosCount 0.0 -}}
+{{- $rucio_daemon := "minos" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.minos.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-minos
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.minosCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: minos
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.minos.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "minos"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.minos.threads }} --threads {{ .Values.minos.threads }}{{ end }} {{- if .Values.minos.bulk }} --bulk {{ .Values.minos.bulk }}{{ end }} {{- if .Values.minos.sleepTime }} --sleep-time {{ .Values.minos.sleepTime }}{{ end}}"
 {{- with .Values.minos.resources }}

--- a/charts/rucio-daemons/templates/necromancer.yaml
+++ b/charts/rucio-daemons/templates/necromancer.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.necromancerCount 0.0 -}}
+{{- $rucio_daemon := "necromancer" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.necromancer.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-necromancer
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.necromancerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: necromancer
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.necromancer.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "necromancer"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.necromancer.threads }} --threads {{ .Values.necromancer.threads }}{{ end }} {{- if .Values.necromancer.bulk }} --bulk {{ .Values.necromancer.bulk }}{{ end }}"
 {{- with .Values.necromancer.resources }}

--- a/charts/rucio-daemons/templates/oauth-manager.yaml
+++ b/charts/rucio-daemons/templates/oauth-manager.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.oauthManagerCount 0.0 -}}
+{{- $rucio_daemon := "oauth-manager" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.oauth-manager.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-oauth-manager
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.oauthManagerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: oauth-manager
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.oauth-manager.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
@@ -111,7 +115,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "oauth-manager"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.oauthManager.threads }} --threads {{ .Values.oauthManager.threads }}{{ end }} {{- if .Values.oauthManager.loopRate }} --loop-rate {{ .Values.oauthManager.loopRate }}{{ end }} {{- if .Values.oauthManager.maxRows }} --max-rows {{ .Values.oauthManager.maxRows }}{{ end }}"
 {{- with .Values.oauthManager.resources }}

--- a/charts/rucio-daemons/templates/reaper.yaml
+++ b/charts/rucio-daemons/templates/reaper.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.reaperCount 0.0 -}}
+{{- $rucio_daemon := "reaper" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.reaper.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-reaper
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.reaperCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: reaper
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.reaper.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "reaper"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: '{{- if .Values.reaper.greedy }}--greedy {{ end }}{{- if .Values.reaper.threads }} --threads {{ .Values.reaper.threads }}{{end}} {{- if .Values.reaper.scheme }} --scheme {{ .Values.reaper.scheme }}{{ end }}{{- if .Values.reaper.includeDids }} --include-dids="{{ .Values.reaper.includeDids }}"{{ end }}{{- if .Values.reaper.excludeDids }} --exclude-dids="{{ .Values.reaper.excludeDids }}"{{ end }} {{- if .Values.reaper.includeRses }} --include-rses="{{ .Values.reaper.includeRses }}"{{ end }} {{- if .Values.reaper.rses }} --rses {{ .Values.reaper.rses }}{{ end }} {{- if .Values.reaper.chunkSize }}  --chunk-size {{ .Values.reaper.chunkSize }}{{ end }} {{- if .Values.reaper.excludeRses }} --exclude-rses="{{ .Values.reaper.excludeRses }}"{{ end }} {{- if .Values.reaper.delaySeconds }} --delay-seconds {{ .Values.reaper.delaySeconds }}{{end}} {{- if .Values.reaper.sleepTime }} --sleep-time {{ .Values.reaper.sleepTime }}{{end}}'
             - name: GLOBUS_THREAD_MODEL

--- a/charts/rucio-daemons/templates/service.yaml
+++ b/charts/rucio-daemons/templates/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "rucio.fullname" . }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -16,6 +16,6 @@ spec:
       protocol: TCP
       name: metrics
   selector:
-    app: {{ template "rucio.name" . }}
+    app-group: {{ template "rucio.name" . }}
     release: {{ .Release.Name }}
 {{ end }}

--- a/charts/rucio-daemons/templates/servicemonitor.yaml
+++ b/charts/rucio-daemons/templates/servicemonitor.yaml
@@ -25,6 +25,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app-group: {{ template "rucio.name" . }}
       release: {{ .Release.Name }}
 {{ end }}

--- a/charts/rucio-daemons/templates/tracer-kronos.yaml
+++ b/charts/rucio-daemons/templates/tracer-kronos.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.tracerKronosCount 0.0 -}}
+{{- $rucio_daemon := "tracer-kronos" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.tracer-kronos.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-tracer-kronos
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.tracerKronosCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: tracer-kronos
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.tracer-kronos.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       {{- range $key, $val := .Values.additionalSecrets }}
       - name: {{ $key }}
         secret:
@@ -97,7 +101,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "kronos"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.tracerKronos.threads }} --threads {{ .Values.tracerKronos.threads }}{{end}} {{- if .Values.tracerKronos.sleepTimeFiles }} --sleep-time-files {{ .Values.tracerKronos.sleepTimeFiles }}{{ end }}{{- if .Values.tracerKronos.sleepTimeDatasets }} --sleep-time-datasets {{ .Values.tracerKronos.sleepTimeDatasets }}{{ end }}"
 {{- with .Values.tracerKronos.resources }}

--- a/charts/rucio-daemons/templates/transmogrifier.yaml
+++ b/charts/rucio-daemons/templates/transmogrifier.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.transmogrifierCount 0.0 -}}
+{{- $rucio_daemon := "transmogrifier" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.transmogrifier.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-transmogrifier
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.transmogrifierCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: transmogrifier
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.transmogrifier.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -116,7 +120,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "transmogrifier"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.transmogrifier.threads }} --threads {{ .Values.transmogrifier.threads }}{{end}} {{- if .Values.transmogrifier.bulk }} --bulk {{ .Values.transmogrifier.bulk }}{{ end }}{{- if .Values.transmogrifier.sleepTime }} --sleep-time {{ .Values.transmogrifier.sleepTime }}{{ end }}"
 {{- with .Values.transmogrifier.resources }}

--- a/charts/rucio-daemons/templates/undertaker.yaml
+++ b/charts/rucio-daemons/templates/undertaker.yaml
@@ -1,10 +1,12 @@
 {{- if gt .Values.undertakerCount 0.0 -}}
+{{- $rucio_daemon := "undertaker" }}
+{{- $app_label := printf "%s-%s" (include "rucio.name" .) $rucio_daemon }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.undertaker.yaml
+  name: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -18,9 +20,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-undertaker
+  name: {{ .Release.Name }}-{{ $rucio_daemon }}
   labels:
-    app: {{ template "rucio.name" . }}
+    app: {{ $app_label }}
+    app-group: {{ template "rucio.name" . }}
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +31,7 @@ spec:
   replicas: {{ .Values.undertakerCount }}
   selector:
     matchLabels:
-      app: {{ template "rucio.name" . }}
+      app: {{ $app_label }}
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.strategy.type }}
@@ -42,9 +45,10 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "rucio.name" . }}
+        app: {{ $app_label }}
+        app-group: {{ template "rucio.name" . }}
         release: {{ .Release.Name }}
-        rucio-daemon: undertaker
+        rucio-daemon: {{ $rucio_daemon }}
     {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -63,7 +67,7 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.undertaker.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       - name: proxy-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
@@ -111,7 +115,7 @@ spec:
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/rucio.config.common.json /opt/rucio/etc/rucio.config.component.json"
             - name: RUCIO_DAEMON
-              value: "undertaker"
+              value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if .Values.undertaker.threads }} --total-workers {{ .Values.undertaker.threads }}{{end}} {{- if .Values.undertaker.chunkSize }} --chunk-size {{ .Values.undertaker.chunkSize }}{{ end }}"
 {{- with .Values.undertaker.resources }}


### PR DESCRIPTION
Many kubernetes helper tools use this label to distinguish between
applications. Until now, all pods in the rucio-daemons chart where
assigned the same "app: rucio-daemons" label.

This is also problematic, and surprising that everything worked
correctly, because the deployment pod selector was the same for all
deployments, which is explicitly discouraged in the documentation:
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#selector

The new app label includes the daemon name: `rucio-daemons-conveyor-poller`
for example. The label `app-group` will now contain the old content of the
'app' label.