### PR TITLE
daemons: use sleepTime instead of delay in hermes

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 1.29.3
+version: 1.29.4
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/hermes.yaml
+++ b/charts/rucio-daemons/templates/hermes.yaml
@@ -126,7 +126,7 @@ spec:
             - name: RUCIO_DAEMON
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
-              value: "{{- if .Values.hermes.threads }} --threads {{ .Values.hermes.threads }}{{ end }} {{- if .Values.hermes.bulk }} --bulk {{ .Values.hermes.bulk }}{{ end }} {{- if .Values.hermes.delay }} --delay {{ .Values.hermes.delay }}{{ end }} {{- if .Values.hermes.brokerTimeout }} --broker-timeout {{ .Values.hermes.brokerTimeout }}{{ end }} {{- if .Values.hermes.brokerRetry }} --broker-retry {{ .Values.hermes.brokerRetry }}{{ end }}"
+              value: "{{- if .Values.hermes.threads }} --threads {{ .Values.hermes.threads }}{{ end }} {{- if .Values.hermes.bulk }} --bulk {{ .Values.hermes.bulk }}{{ end }} {{- if .Values.hermes.sleepTime }} --sleep-time {{ .Values.hermes.sleepTime }}{{ end }} {{- if .Values.hermes.brokerTimeout }} --broker-timeout {{ .Values.hermes.brokerTimeout }}{{ end }} {{- if .Values.hermes.brokerRetry }} --broker-retry {{ .Values.hermes.brokerRetry }}{{ end }}"
 {{- with .Values.hermes.resources }}
           resources:
 {{ toYaml . | trim | indent 12 }}

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -204,7 +204,7 @@ hermes:
   threads: 1
   podAnnotations: {}
   bulk: 100
-  delay: 10
+  sleepTime: 10
   brokerTimeout: 3
   resources:
     limits:


### PR DESCRIPTION
It wasn't used by hermes, so got removed from rucio in last release.
Effectively breaking helm charts