### PR TITLE
Make pods to restart configurable

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 1.29.4
+version: 1.29.5
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-daemons/templates/automatic-restart-cronjob.yaml
@@ -14,6 +14,6 @@ spec:
             - name: restart-pods
               image: "{{ .Values.automaticRestart.image.repository }}:{{ .Values.automaticRestart.image.tag }}"
               imagePullPolicy: {{ .Values.automaticRestart.image.pullPolicy }}
-              command: ["/bin/sh", "-c", "kubectl get deployment -l app-group=rucio-daemons -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | xargs -n 1 kubectl rollout restart deployment"]
+              command: ["/bin/sh", "-c", "kubectl get deployment -l {{ .Values.automaticRestart.selectorLabel }} -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | xargs -n 1 kubectl rollout restart deployment"]
           restartPolicy: OnFailure
 {{ end }}

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -378,6 +378,7 @@ automaticRestart:
     tag: latest
     pullPolicy: IfNotPresent
   schedule: "0 0 * * *"
+  selectorLabel: "app-group=rucio-daemons"
 
 additionalSecrets: {}
   # gcssecret:

--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.29.0
+version: 1.29.1
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-server/templates/automatic-restart-cronjob.yaml
@@ -14,6 +14,6 @@ spec:
             - name: restart-pods
               image: "{{ .Values.automaticRestart.image.repository }}:{{ .Values.automaticRestart.image.tag }}"
               imagePullPolicy: {{ .Values.automaticRestart.image.pullPolicy }}
-              command: ["/bin/sh", "-c", "kubectl get deployment -l 'app in (rucio-server,rucio-server-trace,rucio-server-auth)' -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | xargs -n 1 kubectl rollout restart deployment"]
+              command: ["/bin/sh", "-c", "kubectl get deployment -l {{ .Values.automaticRestart.selectorLabel }} -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | xargs -n 1 kubectl rollout restart deployment"]
           restartPolicy: OnFailure
 {{ end }}

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -132,6 +132,7 @@ automaticRestart:
     tag: latest
     pullPolicy: IfNotPresent
   schedule: "0 0 * * *"
+  selectorLabel: "'app in (rucio-server,rucio-server-trace,rucio-server-auth)'"
 
 additionalSecrets: {}
   # gcssecret:


### PR DESCRIPTION
CMS does not want to restart all the pods, but I want to try this for a couple. This allows you to tag individual daemons with `podLabels: key=value` and reconfigure the restarter to use that label instead of all pods in the daemons/servers. 