### PR TITLE
Mistakenly assumed we were moving these to ENV variables already

### DIFF
--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 1.29.1
+version: 1.29.2
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/deployment.yaml
+++ b/charts/rucio-ui/templates/deployment.yaml
@@ -128,6 +128,13 @@ spec:
               mountPath: {{ $val.mountPath }}
             {{- end}}
           env:
+            {{- range $key, $val := .Values.httpd_config }}
+            - name: RUCIO_HTTPD_{{ $key | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "rucio.fullname" $ }}.cfg
+                  key: {{ $key }}
+            {{- end}}
             {{- range $key1, $val1 := .Values.optional_config }}
             - name: {{ $key1 | upper }}
               value: "{{ $val1  }}"


### PR DESCRIPTION
This is an oversight, I thought we are already populating environment variables since the setting was there in the helm chart. Lifted from rucio-server. 