### PR TITLE
All: rework additionalSecrets usage. #110

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 1.29.5
+version: 1.29.6
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/abacus-account.yaml
+++ b/charts/rucio-daemons/templates/abacus-account.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/abacus-collection-replica.yaml
+++ b/charts/rucio-daemons/templates/abacus-collection-replica.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/abacus-rse.yaml
+++ b/charts/rucio-daemons/templates/abacus-rse.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/automatix.yaml
+++ b/charts/rucio-daemons/templates/automatix.yaml
@@ -78,9 +78,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle-reaper
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -105,7 +105,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/cache-consumer.yaml
+++ b/charts/rucio-daemons/templates/cache-consumer.yaml
@@ -69,9 +69,9 @@ spec:
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -90,7 +90,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
           {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
           {{- end}}

--- a/charts/rucio-daemons/templates/conveyor-finisher.yaml
+++ b/charts/rucio-daemons/templates/conveyor-finisher.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
           {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
           {{- end}}

--- a/charts/rucio-daemons/templates/conveyor-poller.yaml
+++ b/charts/rucio-daemons/templates/conveyor-poller.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
           {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
           {{- end}}

--- a/charts/rucio-daemons/templates/conveyor-preparer.yaml
+++ b/charts/rucio-daemons/templates/conveyor-preparer.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
           {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
           {{- end}}

--- a/charts/rucio-daemons/templates/conveyor-receiver.yaml
+++ b/charts/rucio-daemons/templates/conveyor-receiver.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/conveyor-stager.yaml
+++ b/charts/rucio-daemons/templates/conveyor-stager.yaml
@@ -66,9 +66,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}

--- a/charts/rucio-daemons/templates/conveyor-submitter.yaml
+++ b/charts/rucio-daemons/templates/conveyor-submitter.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/conveyor-throttler.yaml
+++ b/charts/rucio-daemons/templates/conveyor-throttler.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/dark-reaper.yaml
+++ b/charts/rucio-daemons/templates/dark-reaper.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle-reaper
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/hermes.yaml
+++ b/charts/rucio-daemons/templates/hermes.yaml
@@ -77,9 +77,9 @@ spec:
             secretName: {{ .Release.Name }}-hermes-key
 {{ end }}
         {{- range $key, $val := .Values.additionalSecrets }}
-        - name: {{ $key }}
+        - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
           secret:
-            secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+            secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
         {{- end}}
         {{- range $key, $val := .Values.persistentVolumes }}
         - name: {{ $key }}
@@ -104,7 +104,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/hermes2.yaml
+++ b/charts/rucio-daemons/templates/hermes2.yaml
@@ -77,9 +77,9 @@ spec:
             secretName: {{ .Release.Name }}-hermes2-key
 {{ end }}
         {{- range $key, $val := .Values.additionalSecrets }}
-        - name: {{ $key }}
+        - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
           secret:
-            secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+            secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
         {{- end}}
         {{- range $key, $val := .Values.persistentVolumes }}
         - name: {{ $key }}
@@ -104,7 +104,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/judge-cleaner.yaml
+++ b/charts/rucio-daemons/templates/judge-cleaner.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/judge-evaluator.yaml
+++ b/charts/rucio-daemons/templates/judge-evaluator.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/judge-injector.yaml
+++ b/charts/rucio-daemons/templates/judge-injector.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/judge-repairer.yaml
+++ b/charts/rucio-daemons/templates/judge-repairer.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/minos-temporary-expiration.yaml
+++ b/charts/rucio-daemons/templates/minos-temporary-expiration.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/minos.yaml
+++ b/charts/rucio-daemons/templates/minos.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/necromancer.yaml
+++ b/charts/rucio-daemons/templates/necromancer.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/oauth-manager.yaml
+++ b/charts/rucio-daemons/templates/oauth-manager.yaml
@@ -72,9 +72,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -95,7 +95,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
           {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
           {{- end}}

--- a/charts/rucio-daemons/templates/reaper.yaml
+++ b/charts/rucio-daemons/templates/reaper.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle-reaper
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/tracer-kronos.yaml
+++ b/charts/rucio-daemons/templates/tracer-kronos.yaml
@@ -69,9 +69,9 @@ spec:
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}.yaml
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
@@ -85,7 +85,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/transmogrifier.yaml
+++ b/charts/rucio-daemons/templates/transmogrifier.yaml
@@ -75,9 +75,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/rucio/etc/rucio.config.component.json
               subPath: rucio.config.component.json
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-daemons/templates/undertaker.yaml
+++ b/charts/rucio-daemons/templates/undertaker.yaml
@@ -72,9 +72,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-rucio-x509up
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -95,7 +95,7 @@ spec:
             - name: proxy-volume
               mountPath: /opt/proxy
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}

--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.29.1
+version: 1.29.2
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/auth_deployment.yaml
+++ b/charts/rucio-server/templates/auth_deployment.yaml
@@ -55,9 +55,9 @@ spec:
       - name: httpdlog
         emptyDir: {}
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -136,12 +136,12 @@ spec:
             {{- /* TODO: depreacte and remove support for subPaths (at plural) case */}}
             {{-  if $val.subPaths }}
             {{-   range $val.subPaths }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}{{ . }}
               subPath: {{ . }}
             {{-   end}}
             {{-  else }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{-  end}}

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -63,9 +63,9 @@ spec:
       - name: httpdlog
         emptyDir: {}
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -130,12 +130,12 @@ spec:
           {{- /* TODO: depreacte and remove support for subPaths (at plural) case */}}
           {{-  if $val.subPaths }}
           {{-   range $val.subPaths }}
-          - name: {{ $key }}
+          - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
             mountPath: {{ $val.mountPath }}{{ . }}
             subPath: {{ . }}
           {{-   end}}
           {{-  else }}
-          - name: {{ $key }}
+          - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
             mountPath: {{ $val.mountPath }}
             subPath: {{ $val.subPath }}
           {{-  end}}

--- a/charts/rucio-server/templates/trace_deployment.yaml
+++ b/charts/rucio-server/templates/trace_deployment.yaml
@@ -55,9 +55,9 @@ spec:
       - name: httpdlog
         emptyDir: {}
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
 {{- if .Values.useSSL.traceServer }}
       - name: hostcert
@@ -142,12 +142,12 @@ spec:
             {{- /* TODO: depreacte and remove support for subPaths (at plural) case */}}
             {{-  if $val.subPaths }}
             {{-   range $val.subPaths }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}{{ . }}
               subPath: {{ . }}
             {{-   end}}
             {{-  else }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{-  end}}

--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 1.29.2
+version: 1.29.3
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/deployment.yaml
+++ b/charts/rucio-ui/templates/deployment.yaml
@@ -68,9 +68,9 @@ spec:
           secretName: {{ .Release.Name }}-cafile
       {{- end }}
       {{- range $key, $val := .Values.additionalSecrets }}
-      - name: {{ $key }}
+      - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }}
         secret:
-          secretName: {{ $.Release.Name }}-{{ $val.secretName }}
+          secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
       {{- range $key, $val := .Values.persistentVolumes }}
       - name: {{ $key }}
@@ -119,7 +119,7 @@ spec:
               subPath: ca.pem
             {{- end}}
             {{- range $key, $val := .Values.additionalSecrets }}
-            - name: {{ $key }}
+            - name: {{ kindIs "int" $key | ternary (coalesce $val.volumeName $val.secretName $val.secretFullName) $key }} 
               mountPath: {{ $val.mountPath }}
               subPath: {{ $val.subPath }}
             {{- end}}


### PR DESCRIPTION
Until this commit, additional secrets had the following format:
```
    additionalSecrets:
      secret-volume-name:
        secretName: suffix-of-the-secret-name
        mountPath: /some/path.json
        subPath: field_in_secret_to_be_mounted.json
```

This resulted in the following pod config:
```
    spec:
      volumes:
      - name: secret-volume-name
        secret:
          secretName: helm-release-name-suffix-of-the-secret-name
      containers:
        - volumeMounts:
            - name: secret-volume-name
              mountPath: /some/path.json
              subPath: field_in_secret_to_be_mounted.json
```

There are two main issues with this configuration:
- secretName is always prefixed with the helm release. There is no way to refer to the same secret from multiple helm releases inside the same namespace. Requiring the creation of duplicate secrets for each release.
- `secret-volume-name`, which is functionally a value, is put as a key in the yaml, complicating some operations with the yaml object. For example: path traversal inside the yaml.

Rework all helm charts to accept both the current format and a new format:
```
    additionalSecrets:
      - volumeName: secret-volume-name
        secretFullName: full-name-of-the-secret
        mountPath: /some/path.json
        subPath: field_in_secret_to_be_mounted.json
```

This solves the two previously mentioned issues.

To implement compatibility with both the old and new format, we relly on the fact that `range` also works on arrays, returning as keys the array indexes.

The commit also implements a small quality of life improvement:
- default volumeName to secretName. In practice, in most cases, users set both to the same value anyway.

In a future major release it may be worth getting rid of the old format, but that will be a breaking change for everybody.