### PR TITLE
Adding namespace parameter to the missing commands in notes

### DIFF
--- a/charts/rucio-server/templates/NOTES.txt
+++ b/charts/rucio-server/templates/NOTES.txt
@@ -9,11 +9,11 @@
   curl http://$NODE_IP:$NODE_PORT/ping
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "rucio.fullname" . }}'
+           You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "rucio.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "rucio.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "rucio.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:80
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
 {{- end }}

--- a/charts/rucio-ui/templates/NOTES.txt
+++ b/charts/rucio-ui/templates/NOTES.txt
@@ -9,11 +9,11 @@
   curl http://$NODE_IP:$NODE_PORT/ping
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "rucio.fullname" . }}'
+           You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "rucio.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "rucio.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "rucio.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:80
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
 {{- end }}


### PR DESCRIPTION
While running some of the commands which are giving by notes.txt, those are failing because of namespace parameter is not there for some of the commands.