### PR TITLE
Move CronJob to the new API before it is removed.

### DIFF
--- a/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -60,7 +60,7 @@
 
 {{- if .Values.ftsRenewal.enabled -}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-renew-fts-proxy


### PR DESCRIPTION
I keep getting warnings from kubectl when deploying that this is going away "soon". Let's fix that.