### PR TITLE
Daemons additional resource specs

### DIFF
--- a/charts/rucio-daemons/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-daemons/templates/automatic-restart-cronjob.yaml
@@ -15,5 +15,7 @@ spec:
               image: "{{ .Values.automaticRestart.image.repository }}:{{ .Values.automaticRestart.image.tag }}"
               imagePullPolicy: {{ .Values.automaticRestart.image.pullPolicy }}
               command: ["/bin/sh", "-c", "kubectl get deployment -l {{ .Values.automaticRestart.selectorLabel }} -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | xargs -n 1 kubectl rollout restart deployment"]
+              resources:
+{{ toYaml .Values.automaticRestart.resources | indent 15 }}
           restartPolicy: OnFailure
 {{ end }}

--- a/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -23,6 +23,8 @@
     - name: renew-fts-cron
       image: "{{ .Values.ftsRenewal.image.repository }}:{{ .Values.ftsRenewal.image.tag }}"
       imagePullPolicy: {{ .Values.ftsRenewal.image.pullPolicy }}
+      resources:
+{{ toYaml .Values.ftsRenewal.resources | indent 15 }}
       volumeMounts:
   {{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
         - name: longproxy

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -398,6 +398,13 @@ automaticRestart:
     pullPolicy: IfNotPresent
   schedule: "0 0 * * *"
   selectorLabel: "app-group=rucio-daemons"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 additionalSecrets: {}
   # gcssecret:

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -382,6 +382,13 @@ ftsRenewal:
   vo: "cms"
   voms: "cms:/cms/Role=production"
   servers: "https://fts3-devel.cern.ch:8446,https://cmsfts3.fnal.gov:8446,https://fts3.cern.ch:8446,https://lcgfts3.gridpp.rl.ac.uk:8446,https://fts3-pilot.cern.ch:8446"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 automaticRestart:
   enabled: 0


### PR DESCRIPTION
Add a resource request for the Daemons restart cronjob to avoid:
```
Error: failed post-install: warning: Hook post-install rucio-daemons/templates/renew-fts-cronjob.yaml failed: admission webhook "job.nrp-nautilus.io" denied the request: Please specify requests and limits for CPU and memory.
```
on NRP/Nautilus k8s cluster.

Equivalent to #103 for server charts.