### PR TITLE
all: make CronJob compatible with k8s 1.25+. Closes #118

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 1.29.9
+version: 1.29.10
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/_helpers.tpl
+++ b/charts/rucio-daemons/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "rucio.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Get CronJob Kube API Version
+*/}}
+{{- define "rucio.kubeApiVersion.cronjob" -}}
+  {{- if semverCompare ">= 1.22.x" (default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride) -}}
+    {{- print "batch/v1" -}}
+  {{- else -}}
+    {{- print "batch/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/rucio-daemons/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-daemons/templates/automatic-restart-cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.automaticRestart.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: {{ template "rucio.kubeApiVersion.cronjob" . }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-automatic-restart

--- a/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -62,7 +62,7 @@
 
 {{- if .Values.ftsRenewal.enabled -}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: {{ template "rucio.kubeApiVersion.cronjob" . }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-renew-fts-proxy

--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.29.3
+version: 1.29.4
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/_helpers.tpl
+++ b/charts/rucio-server/templates/_helpers.tpl
@@ -34,10 +34,21 @@ Create chart name and version as used by the chart label.
 {{/*
 Get Ingress Kube API Version
 */}}
-{{- define "rucio.ingress.apiVersion" -}}
+{{- define "rucio.kubeApiVersion.ingress" -}}
   {{- if semverCompare ">= 1.19.x" (default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride) -}}
     {{- print "networking.k8s.io/v1" -}}
   {{- else -}}
     {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Get CronJob Kube API Version
+*/}}
+{{- define "rucio.kubeApiVersion.cronjob" -}}
+  {{- if semverCompare ">= 1.22.x" (default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride) -}}
+    {{- print "batch/v1" -}}
+  {{- else -}}
+    {{- print "batch/v1beta1" -}}
   {{- end -}}
 {{- end -}}

--- a/charts/rucio-server/templates/auth_ingress.yaml
+++ b/charts/rucio-server/templates/auth_ingress.yaml
@@ -2,8 +2,8 @@
 {{- if .Values.authIngress.enabled -}}
 {{- $fullName := include "rucio.fullname" . -}}
 {{- $ingressPath := .Values.authIngress.path -}}
-{{- $kubeApiVersion := include "rucio.ingress.apiVersion" . -}}
-apiVersion: {{ $kubeApiVersion }}
+{{- $ingressApiVersion := include "rucio.kubeApiVersion.ingress" . -}}
+apiVersion: {{ $ingressApiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}-auth
@@ -34,7 +34,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-    {{- if eq $kubeApiVersion "networking.k8s.io/v1" }}
+    {{- if eq $ingressApiVersion "networking.k8s.io/v1" }}
               service:
                 name: {{ $fullName }}-auth
                 port:

--- a/charts/rucio-server/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-server/templates/automatic-restart-cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.automaticRestart.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: {{ template "rucio.kubeApiVersion.cronjob" . }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-automatic-restart

--- a/charts/rucio-server/templates/ingress.yaml
+++ b/charts/rucio-server/templates/ingress.yaml
@@ -2,8 +2,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rucio.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- $kubeApiVersion := include "rucio.ingress.apiVersion" . -}}
-apiVersion: {{ $kubeApiVersion }}
+{{- $ingressApiVersion := include "rucio.kubeApiVersion.ingress" . -}}
+apiVersion: {{ $ingressApiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -34,7 +34,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-    {{- if eq $kubeApiVersion "networking.k8s.io/v1" }}
+    {{- if eq $ingressApiVersion "networking.k8s.io/v1" }}
               service:
                 name: {{ $fullName }}
                 port:

--- a/charts/rucio-server/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-server/templates/renew-fts-cronjob.yaml
@@ -62,7 +62,7 @@
 
 {{- if .Values.ftsRenewal.enabled -}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: {{ template "rucio.kubeApiVersion.cronjob" . }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-renew-fts-proxy

--- a/charts/rucio-server/templates/trace_ingress.yaml
+++ b/charts/rucio-server/templates/trace_ingress.yaml
@@ -2,8 +2,8 @@
 {{- if .Values.traceIngress.enabled -}}
 {{- $fullName := include "rucio.fullname" . -}}
 {{- $ingressPath := .Values.traceIngress.path -}}
-{{- $kubeApiVersion := include "rucio.ingress.apiVersion" . -}}
-apiVersion: {{ $kubeApiVersion }}
+{{- $ingressApiVersion := include "rucio.kubeApiVersion.ingress" . -}}
+apiVersion: {{ $ingressApiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}-trace
@@ -34,7 +34,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-    {{- if eq $kubeApiVersion "networking.k8s.io/v1" }}
+    {{- if eq $ingressApiVersion "networking.k8s.io/v1" }}
               service:
                 name: {{ $fullName }}-trace
                 port:

--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 1.29.3
+version: 1.29.4
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/_helpers.tpl
+++ b/charts/rucio-ui/templates/_helpers.tpl
@@ -34,7 +34,7 @@ Create chart name and version as used by the chart label.
 {{/*
 Get Ingress Kube API Version
 */}}
-{{- define "rucio.ingress.apiVersion" -}}
+{{- define "rucio.kubeApiVersion.ingress" -}}
   {{- if semverCompare ">= 1.19.x" (default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride) -}}
     {{- print "networking.k8s.io/v1" -}}
   {{- else -}}

--- a/charts/rucio-ui/templates/ingress.yaml
+++ b/charts/rucio-ui/templates/ingress.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rucio.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- $kubeApiVersion := include "rucio.ingress.apiVersion" . -}}
-apiVersion: {{ $kubeApiVersion }}
+{{- $ingressApiVersion := include "rucio.kubeApiVersion.ingress" . -}}
+apiVersion: {{ $ingressApiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,7 +23,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-    {{- if eq $kubeApiVersion "networking.k8s.io/v1" }}
+    {{- if eq $ingressApiVersion "networking.k8s.io/v1" }}
               service:
                 name: {{ $fullName }}
                 port:


### PR DESCRIPTION
The old API is deprecated already and was removed in 1.25: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125