### PR TITLE
servers & daemons: support relabeling for servicemonitor

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 1.30.0
+version: 1.30.1
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/servicemonitor.yaml
+++ b/charts/rucio-daemons/templates/servicemonitor.yaml
@@ -19,6 +19,14 @@ spec:
  {{- if .Values.monitoring.telemetryPath }}
     path: {{ .Values.monitoring.telemetryPath }}
  {{- end }}
+{{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.monitoring.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.monitoring.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
   jobLabel: {{ template "rucio.fullname" . }}-prometheus-exporter
   namespaceSelector:
     matchNames:

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -58,6 +58,23 @@ monitoring:
   namespace: monitoring
   labels:
     release: prometheus-operator
+  serviceMonitor:
+    ## Metric relabel configs to apply to samples before ingestion.
+    ##
+    metricRelabelings: []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+
+    #   relabel configs to apply to samples before ingestion.
+    ##
+    relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
 
 abacusAccount:
   threads: 1

--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.30.0
+version: 1.30.1
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/auth_servicemonitor.yaml
+++ b/charts/rucio-server/templates/auth_servicemonitor.yaml
@@ -20,11 +20,27 @@ spec:
  {{- if .Values.monitoring.telemetryPath }}
     path: {{ .Values.monitoring.telemetryPath }}
  {{- end }}
+{{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.monitoring.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.monitoring.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
   - targetPort: {{ .Values.monitoring.nativeMetricsPort }}
  {{- if .Values.monitoring.interval }}
     interval: {{ .Values.monitoring.interval }}
  {{- end }}
     path: /metrics/
+{{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.monitoring.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.monitoring.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
   jobLabel: {{ template "rucio.fullname" . }}-prometheus-exporter-auth
   namespaceSelector:
     matchNames:

--- a/charts/rucio-server/templates/servicemonitor.yaml
+++ b/charts/rucio-server/templates/servicemonitor.yaml
@@ -20,11 +20,27 @@ spec:
  {{- if .Values.monitoring.telemetryPath }}
     path: {{ .Values.monitoring.telemetryPath }}
  {{- end }}
+{{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.monitoring.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.monitoring.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
   - targetPort: {{ .Values.monitoring.nativeMetricsPort }}
  {{- if .Values.monitoring.interval }}
     interval: {{ .Values.monitoring.interval }}
  {{- end }}
     path: /metrics/
+{{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.monitoring.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.monitoring.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
   jobLabel: {{ template "rucio.fullname" . }}-prometheus-exporter
   namespaceSelector:
     matchNames:

--- a/charts/rucio-server/templates/trace_servicemonitor.yaml
+++ b/charts/rucio-server/templates/trace_servicemonitor.yaml
@@ -20,11 +20,27 @@ spec:
  {{- if .Values.monitoring.telemetryPath }}
     path: {{ .Values.monitoring.telemetryPath }}
  {{- end }}
+{{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.monitoring.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.monitoring.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
   - targetPort: {{ .Values.monitoring.nativeMetricsPort }}
  {{- if .Values.monitoring.interval }}
     interval: {{ .Values.monitoring.interval }}
  {{- end }}
     path: /metrics/
+{{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.monitoring.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.monitoring.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
   jobLabel: {{ template "rucio.fullname" . }}-prometheus-exporter-trace
   namespaceSelector:
     matchNames:

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -105,6 +105,23 @@ monitoring:
   namespace: monitoring
   labels:
     release: prometheus-operator
+  serviceMonitor:
+    ## Metric relabel configs to apply to samples before ingestion.
+    ##
+    metricRelabelings: []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+
+    #   relabel configs to apply to samples before ingestion.
+    ##
+    relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
 
 metricsExporterResources:
   limits:


### PR DESCRIPTION
This is to perform transformation on metrics before ingestion to prometheus. For example, to mark mertrics which will be forwarded upstream for longer-term storage.