### PR TITLE
enhancement: add lint test workflow for charts fix #95

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,43 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.10.0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.3.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -33,7 +33,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --debug --validate-maintainers=false --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.4.0

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Release Charts](https://github.com/rucio/helm-charts/actions/workflows/release.yml/badge.svg)](https://github.com/rucio/helm-charts/actions/workflows/release.yml) [![Lint and Test Charts](https://github.com/rucio/helm-charts/actions/workflows/lint-test.yml/badge.svg)](https://github.com/rucio/helm-charts/actions/workflows/lint-test.yml)
+
 # Rucio Helm Charts 
 
 ##  Data Management for science in the Big Data era.


### PR DESCRIPTION
This PR fixes #95 by implementing a new helm and lint test workflow in GitHub Actions.
It would probably be a good idea to set this workflow as a merge requirement.