### PR TITLE
servers: support setting additional env values

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.30.3
+version: 1.30.4
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -232,6 +232,9 @@ spec:
               value: "{{ .Values.wsgi.daemonProcesses }}"
             - name: RUCIO_WSGI_DAEMON_THREADS
               value: "{{ .Values.wsgi.daemonThreads }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -181,6 +181,12 @@ additionalSecrets: {}
   #   mountPath: /opt/rucio/etc/gcs_rucio.json
   #   subPath: gcs_rucio.json
 
+additionalEnvs: {}
+  # - name: NODE_IP
+  #   valueFrom:
+  #     fieldRef:
+  #       status.hostIP
+
 wsgi:
   daemonProcesses: "4"
   daemonThreads: "4"


### PR DESCRIPTION
I need to pass the node IP inside the pod for the servers which use the proxy protocol. This is to allow traffic originating from this IP to not use the proxy protocol. Otherwise the health checks (readiness/liviness) probes coming from the kubelet fail.