### PR TITLE
daemons: fix conveyor template

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 1.30.5
+version: 1.30.6
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/conveyor.yaml
+++ b/charts/rucio-daemons/templates/conveyor.yaml
@@ -1,5 +1,6 @@
 {{- define "rucio-daemons.conveyor-deployement" }}
 {{- $app_label := printf "%s-%s" (include "rucio.name" .) .rucio_daemon }}
+---
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
due to merging all conveyor into one, the rendered result doesn't have the correct separator between different components.