### PR TITLE
servers: deprecate implicit ca and proxy volume mounts

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.30.5
+version: 1.30.6
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/auth_deployment.yaml
+++ b/charts/rucio-server/templates/auth_deployment.yaml
@@ -64,6 +64,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ $val.name }}
       {{- end}}
+{{- if .Values.useDeprecatedImplicitSecrets }}
 {{- if .Values.useSSL.authServer }}
       - name: hostcert
         secret:
@@ -74,6 +75,7 @@ spec:
       - name: cafile
         secret:
           secretName: {{ .Release.Name }}-auth-cafile
+{{- end }}
 {{- end }}
       containers:
 {{- if .Values.exposeErrorLogs.authServer }}
@@ -152,6 +154,7 @@ spec:
             - name: {{ $key }}
               mountPath: {{ $val.mountPath }}
             {{- end}}
+{{- if .Values.useDeprecatedImplicitSecrets }}
 {{- if .Values.useSSL.authServer }}
             - name: hostcert
               mountPath: /etc/grid-security/hostcert.pem
@@ -162,6 +165,7 @@ spec:
             - name: cafile
               mountPath: /etc/grid-security/ca.pem
               subPath: ca.pem
+{{- end }}
 {{- end }}
           env:
             {{- range $key, $val := .Values.httpd_config }}

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -1,18 +1,5 @@
 {{- if gt .Values.replicaCount 0.0 -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "rucio.fullname" . }}.config.yaml
-  labels:
-    app: {{ template "rucio.name" . }}
-    chart: "{{ .Chart.Name }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-type: Opaque
-data:
-  {{- $common_config := .Values.config | default dict | mustToPrettyJson | b64enc }}
-  common.json: {{ $common_config | quote }}
----
+{{- $common_config := .Values.config | default dict | mustToPrettyJson | b64enc }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,7 +56,8 @@ spec:
       volumes:
       - name: config
         secret:
-          secretName: {{ template "rucio.fullname" . }}.config.yaml
+          secretName: {{ template "rucio.fullname" . }}.config.common
+      {{- if .Values.useDeprecatedImplicitSecrets }}
       {{- if .Values.ftsRenewal.enabled }}
       - name: proxy-volume
         secret:
@@ -77,6 +65,7 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
+      {{- end }}
       {{- end }}
       - name: httpdlog
         emptyDir: {}
@@ -90,6 +79,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ $val.name }}
       {{- end}}
+{{- if .Values.useDeprecatedImplicitSecrets }}
 {{- if .Values.useSSL.server }}
       - name: hostcert
         secret:
@@ -100,6 +90,7 @@ spec:
       - name: cafile
         secret:
           secretName: {{ .Release.Name }}-server-cafile
+{{- end }}
 {{- end }}
       containers:
 {{- if .Values.exposeErrorLogs.server }}
@@ -136,11 +127,13 @@ spec:
           - name: config
             mountPath: /opt/rucio/etc/conf.d/10_common.json
             subPath: common.json
+          {{- if .Values.useDeprecatedImplicitSecrets }}
           {{- if .Values.ftsRenewal.enabled }}
           - name: proxy-volume
             mountPath: /opt/proxy
           - name: ca-volume
             mountPath: /opt/certs
+          {{- end }}
           {{- end }}
           - name: httpdlog
             mountPath: /var/log/httpd
@@ -162,6 +155,7 @@ spec:
           - name: {{ $key }}
             mountPath: {{ $val.mountPath }}
           {{- end}}
+{{- if .Values.useDeprecatedImplicitSecrets }}
 {{- if .Values.useSSL.server }}
           - name: hostcert
             mountPath: /etc/grid-security/hostcert.pem
@@ -172,6 +166,7 @@ spec:
           - name: cafile
             mountPath: /etc/grid-security/ca.pem
             subPath: ca.pem
+{{- end }}
 {{- end }}
           ports:
             - name: http

--- a/charts/rucio-server/templates/secrets.yaml
+++ b/charts/rucio-server/templates/secrets.yaml
@@ -1,6 +1,20 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ template "rucio.fullname" . }}.config.common
+  labels:
+    app: {{ template "rucio.name" . }}
+    chart: "{{ .Chart.Name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{- $common_config := .Values.config | default dict | mustToPrettyJson | b64enc }}
+  common.json: {{ $common_config | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: {{ template "rucio.fullname" . }}.cfg
   labels:
     app: {{ template "rucio.name" . }}

--- a/charts/rucio-server/templates/trace_deployment.yaml
+++ b/charts/rucio-server/templates/trace_deployment.yaml
@@ -59,6 +59,7 @@ spec:
         secret:
           secretName: {{ coalesce $val.secretFullName (printf "%s-%s" $.Release.Name $val.secretName) }}
       {{- end}}
+{{- if .Values.useDeprecatedImplicitSecrets }}
 {{- if .Values.useSSL.traceServer }}
       - name: hostcert
         secret:
@@ -69,6 +70,7 @@ spec:
       - name: cafile
         secret:
           secretName: {{ .Release.Name }}-trace-cafile
+{{- end }}
 {{- end }}
       containers:
 {{- if .Values.exposeErrorLogs.traceServer }}
@@ -127,6 +129,7 @@ spec:
               subPath: common.json
             - name: httpdlog
               mountPath: /var/log/httpd
+{{- if .Values.useDeprecatedImplicitSecrets }}
 {{- if .Values.useSSL.traceServer }}
             - name: hostcert
               mountPath: /etc/grid-security/hostcert.pem
@@ -137,6 +140,7 @@ spec:
             - name: cafile
               mountPath: /etc/grid-security/ca.pem
               subPath: ca.pem
+{{- end }}
 {{- end }}
             {{- range $key, $val := .Values.additionalSecrets }}
             {{- /* TODO: depreacte and remove support for subPaths (at plural) case */}}


### PR DESCRIPTION
Check the following commit for details:
https://github.com/rucio/helm-charts/commit/8ab83a60e427295fe126cb25d39b977a30471aca