### PR TITLE
servers: add readinessProbe

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.30.9
+version: 1.30.10
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/auth_deployment.yaml
+++ b/charts/rucio-server/templates/auth_deployment.yaml
@@ -120,6 +120,18 @@ spec:
               containerPort: {{ .Values.monitoring.nativeMetricsPort }}
               protocol: TCP
 {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /ping
+{{- if .Values.useSSL.server }}
+              scheme: HTTPS
+              port: 443
+{{- else }}
+              port: 80
+{{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.authServer.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.authServer.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.authServer.timeoutSeconds }}
           livenessProbe:
             httpGet:
               path: /ping

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -166,6 +166,18 @@ spec:
               containerPort: {{ .Values.monitoring.nativeMetricsPort }}
               protocol: TCP
 {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /ping
+{{- if .Values.useSSL.server }}
+              scheme: HTTPS
+              port: 443
+{{- else }}
+              port: 80
+{{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.server.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.server.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.server.timeoutSeconds }}
           livenessProbe:
             httpGet:
               path: /ping

--- a/charts/rucio-server/templates/trace_deployment.yaml
+++ b/charts/rucio-server/templates/trace_deployment.yaml
@@ -113,6 +113,18 @@ spec:
               containerPort: {{ .Values.monitoring.nativeMetricsPort }}
               protocol: TCP
 {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /ping
+{{- if .Values.useSSL.server }}
+              scheme: HTTPS
+              port: 443
+{{- else }}
+              port: 80
+{{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.traceServer.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.traceServer.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.traceServer.timeoutSeconds }}
           livenessProbe:
             httpGet:
               path: /ping

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -83,6 +83,20 @@ minReadySeconds:
   authServer: 5
   traceServer: 5
 
+readinessProbe:
+  server:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+  authServer:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+  traceServer:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+
 livenessProbe:
   server:
     initialDelaySeconds: 10


### PR DESCRIPTION
To avoid sending traffic to pods which didn't yet fully start.