### PR TITLE
daemons: support custom image tag in each component

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 1.30.9
+version: 1.30.10
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/ci/testing-values.yaml
+++ b/charts/rucio-daemons/ci/testing-values.yaml
@@ -135,6 +135,8 @@ conveyorReceiver:
     requests:
       memory: "100Mi"
       cpu: "100m"
+  image:
+    tag: newertag
   secretMounts:
     - secretName: component-overriding-secret
       mountPath: /some/path.json
@@ -152,6 +154,8 @@ conveyorThrottler:
 darkReaper:
   workers: 1
   includeRses: "(type=CALIBDISK|type=DATADISK|type=GROUPDISK|type=LOCALGROUPDISK|type=SCRATCHDISK)"
+  image:
+    tag: newertag
   resources:
     limits:
       memory: "100Mi"

--- a/charts/rucio-daemons/templates/abacus-account.yaml
+++ b/charts/rucio-daemons/templates/abacus-account.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/abacus-collection-replica.yaml
+++ b/charts/rucio-daemons/templates/abacus-collection-replica.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/abacus-rse.yaml
+++ b/charts/rucio-daemons/templates/abacus-rse.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/automatix.yaml
+++ b/charts/rucio-daemons/templates/automatix.yaml
@@ -97,7 +97,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/cache-consumer.yaml
+++ b/charts/rucio-daemons/templates/cache-consumer.yaml
@@ -86,7 +86,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: config-common

--- a/charts/rucio-daemons/templates/conveyor.yaml
+++ b/charts/rucio-daemons/templates/conveyor.yaml
@@ -92,7 +92,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce (.component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/dark-reaper.yaml
+++ b/charts/rucio-daemons/templates/dark-reaper.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/hermes.yaml
+++ b/charts/rucio-daemons/templates/hermes.yaml
@@ -94,7 +94,7 @@ spec:
         {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
 {{ if $component_values.useSSL }}

--- a/charts/rucio-daemons/templates/hermes2.yaml
+++ b/charts/rucio-daemons/templates/hermes2.yaml
@@ -94,7 +94,7 @@ spec:
         {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
 {{ if $component_values.useSSL }}

--- a/charts/rucio-daemons/templates/judge-cleaner.yaml
+++ b/charts/rucio-daemons/templates/judge-cleaner.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/judge-evaluator.yaml
+++ b/charts/rucio-daemons/templates/judge-evaluator.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/judge-injector.yaml
+++ b/charts/rucio-daemons/templates/judge-injector.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/judge-repairer.yaml
+++ b/charts/rucio-daemons/templates/judge-repairer.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/minos-temporary-expiration.yaml
+++ b/charts/rucio-daemons/templates/minos-temporary-expiration.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/minos.yaml
+++ b/charts/rucio-daemons/templates/minos.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/necromancer.yaml
+++ b/charts/rucio-daemons/templates/necromancer.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/oauth-manager.yaml
+++ b/charts/rucio-daemons/templates/oauth-manager.yaml
@@ -91,7 +91,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/reaper.yaml
+++ b/charts/rucio-daemons/templates/reaper.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/replica-recoverer.yaml
+++ b/charts/rucio-daemons/templates/replica-recoverer.yaml
@@ -95,7 +95,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/tracer-kronos.yaml
+++ b/charts/rucio-daemons/templates/tracer-kronos.yaml
@@ -81,7 +81,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: config-common

--- a/charts/rucio-daemons/templates/transmogrifier.yaml
+++ b/charts/rucio-daemons/templates/transmogrifier.yaml
@@ -94,7 +94,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           {{- if .Values.useDeprecatedImplicitSecrets }}

--- a/charts/rucio-daemons/templates/undertaker.yaml
+++ b/charts/rucio-daemons/templates/undertaker.yaml
@@ -91,7 +91,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: config-common

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -34,7 +34,7 @@ necromancerCount: 0
 
 image:
   repository: rucio/rucio-daemons
-  tag: release-1.18.0
+  tag: latest
   pullPolicy: Always
 
 strategy:


### PR DESCRIPTION
It will take precedence over the global tag. This can be useful during transition to alma9, when some components may have to be left behind for some time (reaper for example).