### PR TITLE
servers: support mounting host paths

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.30.11
+version: 1.30.12
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/ci/testing-values.yaml
+++ b/charts/rucio-server/ci/testing-values.yaml
@@ -47,6 +47,12 @@ secretMounts:
     mountPath: /opt/rucio/etc/rse-accounts.cfg
     subPath: rse-accounts.cfg
 
+hostPathMounts:
+  - hostPath: /etc/grid-security/certificates/
+    mountPath: /etc/grid-security/certificates/
+    readOnly: true
+    type: DirectoryOrCreate
+
 additionalSecrets:
   - volumeName: mail-templates
     secretName: mail-templates
@@ -122,6 +128,9 @@ ftsRenewal:
       value: serverint-rucio-x509up
     - name: RUCIO_LONG_PROXY
       value: "latest_x509up.rfc.proxy"
+  extraHostPathMounts:
+    - hostPath: /etc/abc
+      mountPath: /etc/abc
 
 config:
   core:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -63,6 +63,16 @@ spec:
         persistentVolumeClaim:
           claimName: {{ $val.name }}
       {{- end}}
+      {{- range $collection := tuple .Values.hostPathMounts }}
+      {{- range $key, $val := $collection }}
+      - name: {{ $val.volumeName | default (printf "a%s" ($val.mountPath | sha1sum)) }}
+        hostPath:
+          {{- if $val.type }}
+          type: {{ $val.type }}
+          {{- end}}
+          path: {{ $val.hostPath }}
+      {{- end}}
+      {{- end}}
 {{- if .Values.useDeprecatedImplicitSecrets }}
 {{- if .Values.useSSL.server }}
       - name: hostcert
@@ -140,6 +150,13 @@ spec:
           {{- range $key, $val := .Values.persistentVolumes }}
           - name: {{ $key }}
             mountPath: {{ $val.mountPath }}
+          {{- end}}
+          {{- range $collection := tuple .Values.hostPathMounts }}
+          {{- range $key, $val := $collection }}
+          - name: {{ $val.volumeName | default (printf "a%s" ($val.mountPath | sha1sum)) }}
+            mountPath: {{ $val.mountPath }}
+            readOnly: {{ $val.readOnly | default false }}
+          {{- end}}
           {{- end}}
 {{- if .Values.useDeprecatedImplicitSecrets }}
 {{- if .Values.useSSL.server }}

--- a/charts/rucio-server/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-server/templates/renew-fts-cronjob.yaml
@@ -31,6 +31,16 @@
     persistentVolumeClaim:
       claimName: {{ $val.name }}
   {{- end}}
+  {{- range $collection := tuple (coalesce .Values.hostPathMounts .Values.ftsRenewal.hostPathMounts) .Values.ftsRenewal.extraHostPathMounts }}
+  {{- range $key, $val := $collection }}
+  - name: {{ $val.volumeName | default (printf "a%s" ($val.mountPath | sha1sum)) }}
+    hostPath:
+    {{- if $val.type }}
+      type: {{ $val.type }}
+    {{- end}}
+      path: {{ $val.hostPath }}
+  {{- end}}
+  {{- end}}
   containers:
     - name: renew-fts-cron
       image: "{{ .Values.ftsRenewal.image.repository }}:{{ .Values.ftsRenewal.image.tag }}"
@@ -73,6 +83,13 @@
   {{- range $key, $val := .Values.persistentVolumes }}
         - name: {{ $key }}
           mountPath: {{ $val.mountPath }}
+  {{- end}}
+  {{- range $collection := tuple (coalesce .Values.hostPathMounts .Values.ftsRenewal.hostPathMounts) .Values.ftsRenewal.extraHostPathMounts }}
+  {{- range $key, $val := $collection }}
+        - name: {{ $val.volumeName | default (printf "a%s" ($val.mountPath | sha1sum)) }}
+          mountPath: {{ $val.mountPath }}
+          readOnly: {{ $val.readOnly | default false }}
+  {{- end}}
   {{- end}}
       env:
         {{- range $key1, $val1 := .Values.optional_config }}

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -223,6 +223,13 @@ secretMounts: []
   #   mountPath: /opt/rucio/etc/gcs_rucio.json
   #   subPath: gcs_rucio.json
 
+hostPathMounts: []
+  # - volumeName: igtf-ca
+  #   hostPath: /etc/grid-security/certificates/
+  #   mountPath: /etc/grid-security/certificates/
+  #   readOnly: true
+  #   type: DirectoryOrCreate
+
 additionalEnvs: []
   # - name: NODE_IP
   #   valueFrom:


### PR DESCRIPTION
Similarly to secretMounts, add a higher-level primitive 'hostPathMounts' which allows the user to mount a path from the kubernetes host into the container.