### PR TITLE
servers: fix hostPathMounts override direction

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 1.30.12
+version: 1.30.13
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-server/templates/renew-fts-cronjob.yaml
@@ -31,7 +31,7 @@
     persistentVolumeClaim:
       claimName: {{ $val.name }}
   {{- end}}
-  {{- range $collection := tuple (coalesce .Values.hostPathMounts .Values.ftsRenewal.hostPathMounts) .Values.ftsRenewal.extraHostPathMounts }}
+  {{- range $collection := tuple (hasKey .Values.ftsRenewal "hostPathMounts" | ternary .Values.ftsRenewal.hostPathMounts .Values.hostPathMounts) .Values.ftsRenewal.extraHostPathMounts }}
   {{- range $key, $val := $collection }}
   - name: {{ $val.volumeName | default (printf "a%s" ($val.mountPath | sha1sum)) }}
     hostPath:
@@ -84,7 +84,7 @@
         - name: {{ $key }}
           mountPath: {{ $val.mountPath }}
   {{- end}}
-  {{- range $collection := tuple (coalesce .Values.hostPathMounts .Values.ftsRenewal.hostPathMounts) .Values.ftsRenewal.extraHostPathMounts }}
+  {{- range $collection := tuple (hasKey .Values.ftsRenewal "hostPathMounts" | ternary .Values.ftsRenewal.hostPathMounts .Values.hostPathMounts) .Values.ftsRenewal.extraHostPathMounts }}
   {{- range $key, $val := $collection }}
         - name: {{ $val.volumeName | default (printf "a%s" ($val.mountPath | sha1sum)) }}
           mountPath: {{ $val.mountPath }}


### PR DESCRIPTION
We should prefer the override from the fts cronjob over the global value, not the opposite. Also, allow to override with an empty array.