### PR TITLE
Fix Hermes2 configuration secret name

### DIFF
--- a/charts/rucio-daemons/templates/hermes2.yaml
+++ b/charts/rucio-daemons/templates/hermes2.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "rucio.fullname" . }}.config.hermes2.yaml
+  name: {{ template "rucio.fullname" . }}.config.hermes2
   labels:
     app: {{ $app_label }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
Currently the template for Hermes2 on the 1.29 branch inappropriately names the configuration secret for Hermes2. Drop the ".yaml" suffix so that the name matches what the Hermes2 Deployment yaml has filled in by the template.