### PR TITLE
a few changes for webui helm chart

### DIFF
--- a/charts/rucio-webui/templates/deployment.yaml
+++ b/charts/rucio-webui/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
           secretName: {{ template "rucio.fullname" . }}.config.yaml
       - name: httpdlog
         emptyDir: {}
+      {{- if .Values.useDeprecatedImplicitSecrets }}
       {{- if eq .Values.service.useSSL true }}
       - name: hostcert
         secret:
@@ -60,6 +61,7 @@ spec:
       - name: cafile
         secret:
           secretName: {{ .Release.Name }}-cafile
+      {{- end }}
       {{- end }}
       {{- range $key, $val := .Values.secretMounts }}
       - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -98,6 +100,7 @@ spec:
               subPath: common.json
             - name: httpdlog
               mountPath: /var/log/httpd
+            {{- if .Values.useDeprecatedImplicitSecrets }}
             {{- if .Values.service.useSSL }}
             - name: hostcert
               mountPath: /etc/grid-security/hostcert.pem
@@ -108,6 +111,7 @@ spec:
             - name: cafile
               mountPath: /etc/grid-security/ca.pem
               subPath: ca.pem
+            {{- end}}
             {{- end}}
             {{- range $key, $val := .Values.secretMounts }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}

--- a/charts/rucio-webui/templates/ingress.yaml
+++ b/charts/rucio-webui/templates/ingress.yaml
@@ -20,6 +20,16 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{ end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range $.Values.ingress.hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ . }}

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -29,6 +29,9 @@ service:
   # Run the webui server on port 443 instead of 80 and accept X509 certificates
   useSSL: true
   # nodePort:
+  port: 443
+
+useDeprecatedImplicitSecrets: false
 
 ingress:
   enabled: false
@@ -39,6 +42,8 @@ ingress:
   path: /
   hosts: []
   #   - my.rucio.test
+  tls:
+    - secretName: rucio-webui.tls-secret
 
 secretMounts: []
 # - volumeName: gcssecret


### PR DESCRIPTION
I have tried to run webui in our kubernetes cluster, however I found that I had to add some things to the chart.
I didn't succeed in connecting to the webui (nothing seems to run on port 443), but perhaps these changes are still useful. 

See the condensed helmrelease file used below, full version at https://git.km3net.de/rucio/rucio-deployment/-/issues/27#note_61808:

```
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  ...
spec:
  chart:
    ...
  values:
    image:
      repository: git.km3net.de:4567/rucio/rucio-webui-container
    service:
      useSSL: true
      port: 443
    config:
      react:
        rucioHost: rucio.km3net.de
        rucioAuthHost: rucio.km3net.de
    useDeprecatedImplicitSecrets: false
    exposeErrorLogs: false
    ingress:
      enabled: true
      hosts:
        - webui.rucio.km3net.de
      path: /
      annotations:
        kubernetes.io/ingress.class: public
        nginx.ingress.kubernetes.io/ssl-passthrough: "true"
        nginx.ingress.kubernetes.io/ssl-redirect: "true"
      tls:
        - secretName: rucio-webui.tls-secret
    httpdWebui:
      hostname: webui.test.rucio.km3net.de
    oidcProviders: []
    secretMounts:
      - secretFullName: rucio-https-cert
        volumeName: cafile
        mountPath: /etc/grid-security/ca.pem
        subPath: tls.crt
      - secretFullName: rucio-https-cert
        volumeName: hostcert
        mountPath: /etc/grid-security/hostcert.pem
        subPath: tls.crt
      - secretFullName: rucio-https-cert
        volumeName: hostkey
        mountPath: /etc/grid-security/hostkey.pem
        subPath: tls.key
```