### PR TITLE
Fixes for Rucio UI ( not WebUI) 33.x charts

### DIFF
--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 34.0.0
+version: 34.0.1
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/deployment.yaml
+++ b/charts/rucio-ui/templates/deployment.yaml
@@ -156,8 +156,8 @@ spec:
             - name: RUCIO_AUTH_PROXY_SCHEME
               value: {{ .Values.proxy.rucioAuthProxyScheme }}
 {{- end }}
-            - name: RUCIO_DEFINE_ALIASES
-              value: "True"
+            - name: RUCIO_HOSTNAME
+              value: {{ .Values.httpd_config.rucio_hostname }}
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/conf.d/"
             - name: RUCIO_LOG_FORMAT

--- a/charts/rucio-ui/templates/ingress.yaml
+++ b/charts/rucio-ui/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if gt .Values.replicaCount 0.0 -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rucio.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
@@ -37,4 +38,5 @@ spec:
               servicePort: {{ $.Values.service.port }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/rucio-ui/templates/service.yaml
+++ b/charts/rucio-ui/templates/service.yaml
@@ -15,10 +15,13 @@ metadata:
 spec:
   type: {{ $.Values.service.type }}
   ports:
-    - port: {{ $.Values.service.port }}
-      targetPort: {{ $.Values.service.targetPort }}
+    - port: {{ ternary 443 80 $.Values.service.useSSL }}
+      targetPort: {{ ternary "https" "http" $.Values.service.useSSL }}
       protocol: TCP
-      name: {{ $.Values.service.portName }}
+      {{- if $.Values.service.nodePort }}
+      nodePort: {{ $.Values.service.nodePort }}
+      {{- end }}
+      name: {{ ternary "https" "http" $.Values.service.useSSL }}
   selector:
     app: {{ template "rucio.name" . }}
     release: {{ .Release.Name }}

--- a/charts/rucio-ui/values.yaml
+++ b/charts/rucio-ui/values.yaml
@@ -13,14 +13,15 @@ exposeErrorLogs: true
 service:
   type: NodePort
   # Run the webui server on port 443 instead of 80 and accept X509 certificates and proxies
-  useSSL: true
-  port: 443
-  targetPort: https
-  portName: https
+  useSSL: false
+  port: 80
+  targetPort: http
+  nodePort: 30734
+  annotations: []
 
 image:
-  repository: rucio/rucio-ui
-  tag: release-1.21.12
+  repository: maany/rucio-ui
+  tag: release-33.6.1
   pullPolicy: Always
 
 imagePullSecrets: []
@@ -35,20 +36,46 @@ strategy:
 minReadySeconds: 5
 
 proxy:
-  rucioProxy: ""
-  # rucioProxyScheme: "https"
-  rucioAuthProxy: ""
-  # rucioAuthProxyScheme: "https"
+  rucioProxy: "rucio-lb-prod.cern.ch"
+  rucioProxyScheme: "https"
+  rucioAuthProxy: "rucio-auth-prod.cern.ch"
+  rucioAuthProxyScheme: "https"
 
 ingress:
   enabled: false
   # ingressClassName: traefik
   annotations: {}
+    # traefik.ingress.kubernetes.io/frontend-entry-points: http
+    # traefik.ingress.kubernetes.io/redirect-entry-point: https
   path: /
   hosts: []
   #   - my.rucio.test
+  tls:
+    - secretName: rucio-server.tls-secret
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: rucio-server.tls-secret
+  #   key: |+
+  #     -----BEGIN RSA PRIVATE KEY-----
+  #     -----END RSA PRIVATE KEY-----
+  #   certificate: |+
+  #     -----BEGIN CERTIFICATE-----
+  #     -----END CERTIFICATE-----
 
-secretMounts: {}
+
+## Additional secrets to be mounted as files in the ui container.
+## Use this to mount certificates, ca-files for httpd.
+## You can also use this to mount sections of rucio.cfg file. In this case, the mount path
+## should be in the /opt/rucio/etc/conf.d/<file_name>.cfg format.
+secretMounts:
 # - volumeName: gcssecret
 #   secretName: gcssecret
 #   mountPath: /opt/rucio/etc/gcs_rucio.json
@@ -109,10 +136,9 @@ config:
     ## config.permission.support_rucio: (default "https://github.com/rucio/rucio/issues/")
     # support_rucio: "https://github.com/rucio/rucio/issues/"
 
-  ## Only necessary for webui deployments
-  # webui:
-    ## config.webui.usercert:  (default "/opt/rucio/etc/usercert_with_key.pem")
-    # usercert: "/opt/rucio/etc/usercert_with_key.pem"
+# Additional environment variables to be set in the container.
+# For a list, please see: https://github.com/rucio/containers/blob/master/ui/README.md 
+optional_config: {}
 
 resources: {}
   # limits:

--- a/charts/rucio-ui/values.yaml
+++ b/charts/rucio-ui/values.yaml
@@ -21,7 +21,7 @@ service:
 
 image:
   repository: rucio/rucio-ui
-  tag: release-33.6.1
+  tag: release-34.0.0
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/charts/rucio-ui/values.yaml
+++ b/charts/rucio-ui/values.yaml
@@ -16,7 +16,7 @@ service:
   useSSL: true
   port: 443
   targetPort: https
-  nodePort: 30734 # for example
+  nodePort: 30734
   annotations: []
 
 image:
@@ -44,7 +44,8 @@ proxy:
 ingress:
   enabled: false
   # ingressClassName: traefik
-  annotations: {}
+  annotations:
+    {}
     # traefik.ingress.kubernetes.io/frontend-entry-points: http
     # traefik.ingress.kubernetes.io/redirect-entry-point: https
   path: /
@@ -69,7 +70,6 @@ ingress:
   #   certificate: |+
   #     -----BEGIN CERTIFICATE-----
   #     -----END CERTIFICATE-----
-
 
 ## Additional secrets to be mounted as files in the ui container.
 ## Use this to mount certificates, ca-files for httpd.
@@ -96,14 +96,15 @@ httpd_config:
 ## values used to configure Rucio
 config:
   # common:
-    ## config.common.logdir: the default directoy to write logs to (default: "/var/log/rucio")
-    # logdir: "/var/log/rucio"
-    ## config.common.logdir: the max loglevel (default: "DEBUG")
-    # loglevel: "DEBUG"
-    ## config.common.mailtemplatedir: directory containing the mail templates (default: "/opt/rucio/etc/mail_templates")
-    # mailtemplatedir: "/opt/rucio/etc/mail_templates"
+  ## config.common.logdir: the default directoy to write logs to (default: "/var/log/rucio")
+  # logdir: "/var/log/rucio"
+  ## config.common.logdir: the max loglevel (default: "DEBUG")
+  # loglevel: "DEBUG"
+  ## config.common.mailtemplatedir: directory containing the mail templates (default: "/opt/rucio/etc/mail_templates")
+  # mailtemplatedir: "/opt/rucio/etc/mail_templates"
 
-  database: {}
+  database:
+    {}
     ## config.database.default: the connection string for the database (default: "sqlite:////tmp/rucio.db")
     # default: "sqlite:////tmp/rucio.db"
     ## config.database.schema: the schema used in the DB. only necessary when using Oracle.
@@ -126,22 +127,23 @@ config:
     # powuserpassword: ""
 
   # policy:
-    ## config.permission.policy: (default "generic")
-    # permission: "generic"
-    ## config.permission.schema: (default "generic")
-    # schema: "generic"
-    ## config.permission.lfn2pfn_algorithm_default: (default "hash")
-    # lfn2pfn_algorithm_default: "hash"
-    ## config.permission.support: (default "https://github.com/rucio/rucio/issues/")
-    # support: "https://github.com/rucio/rucio/issues/"
-    ## config.permission.support_rucio: (default "https://github.com/rucio/rucio/issues/")
-    # support_rucio: "https://github.com/rucio/rucio/issues/"
+  ## config.permission.policy: (default "generic")
+  # permission: "generic"
+  ## config.permission.schema: (default "generic")
+  # schema: "generic"
+  ## config.permission.lfn2pfn_algorithm_default: (default "hash")
+  # lfn2pfn_algorithm_default: "hash"
+  ## config.permission.support: (default "https://github.com/rucio/rucio/issues/")
+  # support: "https://github.com/rucio/rucio/issues/"
+  ## config.permission.support_rucio: (default "https://github.com/rucio/rucio/issues/")
+  # support_rucio: "https://github.com/rucio/rucio/issues/"
 
 # Additional environment variables to be set in the container.
-# For a list, please see: https://github.com/rucio/containers/blob/master/ui/README.md 
+# For a list, please see: https://github.com/rucio/containers/blob/master/ui/README.md
 optional_config: {}
 
-resources: {}
+resources:
+  {}
   # limits:
   #  cpu: 100m
   #  memory: 128Mi

--- a/charts/rucio-ui/values.yaml
+++ b/charts/rucio-ui/values.yaml
@@ -13,14 +13,14 @@ exposeErrorLogs: true
 service:
   type: NodePort
   # Run the webui server on port 443 instead of 80 and accept X509 certificates and proxies
-  useSSL: false
-  port: 80
-  targetPort: http
-  nodePort: 30734
+  useSSL: true
+  port: 443
+  targetPort: https
+  nodePort: 30734 # for example
   annotations: []
 
 image:
-  repository: maany/rucio-ui
+  repository: rucio/rucio-ui
   tag: release-33.6.1
   pullPolicy: Always
 
@@ -36,9 +36,9 @@ strategy:
 minReadySeconds: 5
 
 proxy:
-  rucioProxy: "rucio-lb-prod.cern.ch"
+  rucioProxy: "<rucio-server-host>"
   rucioProxyScheme: "https"
-  rucioAuthProxy: "rucio-auth-prod.cern.ch"
+  rucioAuthProxy: "<rucio-auth-server-host>"
   rucioAuthProxyScheme: "https"
 
 ingress:
@@ -84,6 +84,7 @@ secretMounts:
 ## values used to configure apache
 httpd_config:
   legacy_dn: "False"
+  rucio_hostname: "my-rucio-ui.example.com"
   # mpm_mode: "event"
   # start_servers: "1"
   # min_spare_threads: "1"


### PR DESCRIPTION
The `rucio-ui` containers were recently updated in https://github.com/rucio/containers/pull/296. The update involved restructuring the Jinja2 templates that generate the httpd config.

This PR reflects back the changes in containers in the helm charts for rucio-ui