### PR TITLE
ui: fix NodePort service spec

### DIFF
--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 34.0.2
+version: 34.0.3
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/service.yaml
+++ b/charts/rucio-ui/templates/service.yaml
@@ -19,12 +19,12 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
       protocol: {{ .Values.service.protocol }}
       name: {{ .Values.service.name }}
+{{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+{{- end }}
   selector:
     app: {{ template "rucio.name" . }}
     release: {{ .Release.Name }}
-{{- if .Values.service.nodePort }}
-  nodePort: {{ .Values.service.nodePort }}
-{{- end }}
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}


### PR DESCRIPTION
move the port spec into the port section ( it was in the selector section earlier)