### PR TITLE
Improvements for webui chart

### DIFF
--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 34.0.2
+version: 34.0.3
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/templates/deployment.yaml
+++ b/charts/rucio-webui/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         emptyDir: {}
       - name: webui-log
         emptyDir: {}
+      {{- if .Values.useDeprecatedImplicitSecrets }}
       {{- if eq .Values.useSSL true }}
       - name: hostcert
         secret:
@@ -62,6 +63,7 @@ spec:
       - name: cafile
         secret:
           secretName: {{ .Release.Name }}-cafile
+      {{- end }}
       {{- end }}
       {{- range $key, $val := .Values.secretMounts }}
       - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -111,6 +113,7 @@ spec:
             - name: webui-log
               mountPath: /root/.pm2/logs/
             {{- end }}
+            {{- if .Values.useDeprecatedImplicitSecrets }}
             {{- if .Values.useSSL }}
             - name: hostcert
               mountPath: /etc/grid-security/hostcert.pem
@@ -121,6 +124,7 @@ spec:
             - name: cafile
               mountPath: /etc/grid-security/ca.pem
               subPath: ca.pem
+            {{- end}}
             {{- end}}
             {{- range $key, $val := .Values.secretMounts }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}

--- a/charts/rucio-webui/templates/ingress.yaml
+++ b/charts/rucio-webui/templates/ingress.yaml
@@ -20,6 +20,16 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{ end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range $.Values.ingress.hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ . }}

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -39,6 +39,8 @@ service:
   externalTrafficPolicy: null
   allocateLoadBalancerNodePorts: true
 
+useDeprecatedImplicitSecrets: false
+
 ingress:
   enabled: false
   # ingressClassName: traefik
@@ -47,6 +49,8 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   path: /
   hosts: []
+  tls:
+    - secretName: rucio-webui.tls-secret
 
 secretMounts: []
 # - volumeName: gcssecret


### PR DESCRIPTION
Hi,

- The addition of `.Values.useDeprecatedImplicitSecrets`
  This change will add the possibility of having non-hostpath-mounted certificates, but instead have them be managed by the user (through kubernetes for example). This option is already present in the `rucio-server` chart, and I think it is very usefull for the webui as well
- The addition of  `.Values.ingress.tls` 
  This change will allow the user to have tls ingress to the webui cluster. This option is also copied from how its done on the `rucio-server`.

Kind Regards,
Victor