### PR TITLE
UI hostpath mounts

### DIFF
--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 34.0.4
+version: 34.0.5
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/deployment.yaml
+++ b/charts/rucio-ui/templates/deployment.yaml
@@ -132,6 +132,13 @@ spec:
               subPath: ca.pem
             {{- end}}
             {{- end}}
+            {{- range $collection := tuple .Values.hostPathMounts }}
+            {{- range $key, $val := $collection }}
+            - name: {{ $val.volumeName | default (printf "a%s" ($val.mountPath | sha1sum)) }}
+              mountPath: {{ $val.mountPath }}
+              readOnly: {{ $val.readOnly | default false }}
+            {{- end}}
+            {{- end}}
             {{- range $key, $val := .Values.secretMounts }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
               mountPath: {{ $val.mountPath }}

--- a/charts/rucio-ui/templates/deployment.yaml
+++ b/charts/rucio-ui/templates/deployment.yaml
@@ -79,6 +79,16 @@ spec:
         persistentVolumeClaim:
           claimName: {{ $val.name }}
       {{- end}}
+      {{- range $collection := tuple .Values.hostPathMounts }}
+      {{- range $key, $val := $collection }}
+      - name: {{ $val.volumeName | default (printf "a%s" ($val.mountPath | sha1sum)) }}
+        hostPath:
+          {{- if $val.type }}
+          type: {{ $val.type }}
+          {{- end}}
+          path: {{ $val.hostPath }}
+      {{- end}}
+      {{- end}}
       containers:
 {{- if .Values.exposeErrorLogs }}
         - name: httpd-error-log

--- a/charts/rucio-ui/values.yaml
+++ b/charts/rucio-ui/values.yaml
@@ -94,6 +94,12 @@ secretMounts:
 #   mountPath: /opt/rucio/etc/gcs_rucio.json
 #   subPath: gcs_rucio.json
 
+# hostPathMounts: []
+  # - volumeName: igtf-ca
+  #   hostPath: /etc/grid-security/certificates/
+  #   mountPath: /etc/grid-security/certificates/
+  #   readOnly: true
+  #   type: DirectoryOrCreate
 ## values used to configure apache
 httpd_config:
   legacy_dn: "False"

--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 34.0.3
+version: 34.0.4
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/templates/service.yaml
+++ b/charts/rucio-webui/templates/service.yaml
@@ -34,7 +34,7 @@ spec:
 {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
 {{- end }}
-{{- if not .Values.service.allocateLoadBalancerNodePorts }}
+{{- if .Values.service.allocateLoadBalancerNodePorts }}
   allocateLoadBalancerNodePorts: {{ .Values.service.allocateLoadBalancerNodePorts }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Allow .Values.hostPathMount to mount volumes from host machines into pods. Useful for mounting certificates and CRLs directly to `/etc/grid-security/certificates` inside pods 