### PR TITLE
webui: improve documentation on certificates, SSL and NODE_EXTRA_TLS_…

### DIFF
--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 34.0.6
+version: 34.0.7
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/README.md
+++ b/charts/rucio-webui/README.md
@@ -132,7 +132,7 @@ There are two types of CA bundles that are used by the WebUI:
 ##### Multiple CA files
 For x509 based authentication, if you have multiple pem encoded CA files, you must mount them at the path specified by the `RUCIO_CA_PATH` environment variable.
 
-You must also set the `RUCIO_CA_PATH` environment variable using the `addtionalEnvs` section to point to the directory where the CA files are mounted. For example, to mount the CA files at `/etc/grid-security/certificates/` and set the `RUCIO_CA_PATH` environment variable to `/etc/grid-security/certificates`, you would set the following in the `values.yaml` file:
+You must also set the `RUCIO_CA_PATH` environment variable using the `additionalEnvs` section to point to the directory where the CA files are mounted. For example, to mount the CA files at `/etc/grid-security/certificates/` and set the `RUCIO_CA_PATH` environment variable to `/etc/grid-security/certificates`, you would set the following in the `values.yaml` file:
 
 ```yaml
 hostPathMounts:

--- a/charts/rucio-webui/README.md
+++ b/charts/rucio-webui/README.md
@@ -152,7 +152,7 @@ The hostPathMounts is just one way to provide the CA files when you have the CA 
 
 If you wish to use a single CA file for x509 authentication, you can provide the CA file as a secret in the same namespace as the WebUI pod, you must mount the file at the path specified by the `RUCIO_CA_FILE` environment variable.
 
-You must also set the `RUCIO_CA_FILE` environment variable using the `addtionalEnvs` section to point to the directory where the CA file is mounted. For example, to mount the CA file at `/etc/grid-security/certificates/ca.pem` and set the `RUCIO_CA_FILE` environment variable to `/etc/grid-security/certificates/ca.pem`, you would set the following in the `values.yaml` file:
+You must also set the `RUCIO_CA_FILE` environment variable using the `additionalEnvs` section to point to the directory where the CA file is mounted. For example, to mount the CA file at `/etc/grid-security/certificates/ca.pem` and set the `RUCIO_CA_FILE` environment variable to `/etc/grid-security/certificates/ca.pem`, you would set the following in the `values.yaml` file:
 
 ```yaml
 hostPathMounts:

--- a/charts/rucio-webui/README.md
+++ b/charts/rucio-webui/README.md
@@ -146,7 +146,7 @@ additionalEnvs:
     value: "/etc/grid-security/certificates"
 ```
 
-The hostPathMounts is just one way to provide the CA files when you have the CA files locally available on your kubernetes nodes. You can also use other methods like `configmaps` or `secrets` to provide the CA files. Please make sure that the CA files are mounted at the path specified by the `RUCIO_CA_PATH` environment variable.
+The `hostPathMounts` is just one way to provide the CA files when you have the CA files locally available on your kubernetes nodes. You can also use other methods like `configmaps` or `secrets` to provide the CA files. Please make sure that the CA files are mounted at the path specified by the `RUCIO_CA_PATH` environment variable.
 
 ##### Single CA file
 

--- a/charts/rucio-webui/README.md
+++ b/charts/rucio-webui/README.md
@@ -1,12 +1,13 @@
 # Rucio
 
-##  Data Management for science in the Big Data era.
+## Data Management for science in the Big Data era.
 
 Rucio is a software framework that provides functionality to organize, manage, and access large volumes of scientific data using customisable policies. The data can be spread across globally distributed locations and across heterogeneous data centers, uniting different storage and network technologies as a single federated entity. Rucio offers advanced features such as distributed data recovery or adaptive replication, and is highly scalable, modular, and extensible. Rucio has been originally developed to meet the requirements of the high-energy physics experiment ATLAS, and is continuously extended to support LHC experiments and other diverse scientific communities.
 
 ## QuickStart
 
 Add the Rucio Helm repository to your local Helm installation:
+
 ```bash
 helm repo add rucio https://rucio.github.io/helm-charts
 ```
@@ -18,6 +19,7 @@ This chart bootstraps a Rucio WebUI deployment and service on a Kubernetes clust
 Rucio WebUI is a [NextJS](https://nextjs.org/) application that provides a web interface to interact with the Rucio server. The application is packaged via PM2 and served using Apache.
 
 ## Configuration
+
 The default configuration values for this chart are listed in `values.yaml` our you can get them with:
 
 ```bash
@@ -34,7 +36,9 @@ helm install \
     -f values.yaml \
     rucio/rucio-webui
 ```
+
 ### Basic Configuration
+
 At the bare minimum, you will need to provide the following parameters:
 `config.webui.rucio_host` - The hostname of the Rucio server to connect to.
 `config.webui.rucio_auth_host` - The hostname of the Rucio authentication server to connect to.
@@ -42,9 +46,11 @@ At the bare minimum, you will need to provide the following parameters:
 `config.webui.project_url`- The public URL of your collaboration's project page.
 
 ### VO Configuration
+
 To configure multiple vo's, you can use the `config.webui.vo` parameter. This parameter is a csv string of the short names of the vo's you want to configure. For example, to configure the `atlas` and `cms` vo's, you would set `config.webui.vo` to `atl,cms`.
 
 For each VO, you will have to provide parameters in the `config.vo` section. For example,
+
 ```yaml
 config:
   vo:
@@ -59,22 +65,15 @@ config:
 ```
 
 ## Service, TLS Termination and Certificates
+
 By default, the WebUI pods will listen on port 80 using plain HTTP and the default services are of type `ClusterIP` on port 80. To run the pods with https you will first have to install the necessary hostcert, hostkey and ca-bundles.
+
 
 The host certificates and CA bundle must be created before the pod start. The certificates and CA bundle must be provided as secrets in the same namespace as the WebUI pod. The secret names must be prepended with the same `Release.Name` of the chart. The secret must contain the following:
 
-### CA Bundle
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {.Release.Name}-cafile
-  namespace: {your_namespace}
-data:
-    ca.pem: {base64 encoded ca.pem}
-type: Opaque
-```
+
 ### Hostcert
+
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -87,6 +86,7 @@ type: Opaque
 ```
 
 ### Hostkey
+
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -97,15 +97,114 @@ data:
     hostkey.pem: {base64 encoded hostkey.pem}
 type: Opaque
 ```
+
 ### Generate Secrets
+
 You can generate the secrets using the following commands:
+
 ```bash
-kubectl create secret generic <releasename>-server-hostcert --from-file=hostcert.pem=/path/to/hostcert.pem   
+kubectl create secret generic <releasename>-server-hostcert --from-file=hostcert.pem=/path/to/hostcert.pem
 kubectl create secret generic <releasename>-server-hostkey --from-file=hostkey.pem=/path/to/hostkey.pem
-kubectl create secret generic <releasename>-server-cafile --from-file=ca.pem=/path/to/ca.pem
 ```
+
+### Mount Secrets
+
+You can mount the secrets into the WebUI pod using the `secretMounts` section. For example:
+
+```yaml
+secretMounts:
+  - name: <releasename>-server-hostcert
+    mountPath: /etc/grid-security/hostcert.pem
+    subPath: hostcert.pem
+  - name: <releasename>-server
+    mountPath: /etc/grid-security/hostkey.pem
+    subPath: hostkey.pem
+```
+
+### CA bundles
+
+There are two types of CA bundles that are used by the WebUI:
+1. For verification of the x509 client certificates, which is done by Apache by setting the `SSLCACertificateFile` or `SSLCACertificatePath` directive in apache configuration.
+2. For verification of the host certificates of the Rucio server, which is done by NodeJS, ultimately by setting the `RUCIO_WEBUI_SERVER_CA_BUNDLE` environment variable in the WebUI container.
+
+
+#### CA bundles for x509 client certificates
+##### Multiple CA files
+For x509 based authentication, if you have multiple pem encoded CA files, you must mount them at the path specified by the `RUCIO_CA_PATH` environment variable.
+
+You must also set the `RUCIO_CA_PATH` environment variable using the `addtionalEnvs` section to point to the directory where the CA files are mounted. For example, to mount the CA files at `/etc/grid-security/certificates/` and set the `RUCIO_CA_PATH` environment variable to `/etc/grid-security/certificates`, you would set the following in the `values.yaml` file:
+
+```yaml
+hostPathMounts:
+  - hostPath: /etc/grid-security/certificates/
+    mountPath: /etc/grid-security/certificates/
+    readOnly: true
+    type: DirectoryOrCreate
+
+additionalEnvs:
+  - name: RUCIO_CA_PATH
+    value: "/etc/grid-security/certificates"
+```
+
+The hostPathMounts is just one way to provide the CA files when you have the CA files locally available on your kubernetes nodes. You can also use other methods like `configmaps` or `secrets` to provide the CA files. Please make sure that the CA files are mounted at the path specified by the `RUCIO_CA_PATH` environment variable.
+
+##### Single CA file
+
+If you wish to use a single CA file for x509 authentication, you can provide the CA file as a secret in the same namespace as the WebUI pod, you must mount the file at the path specified by the `RUCIO_CA_FILE` environment variable.
+
+You must also set the `RUCIO_CA_FILE` environment variable using the `addtionalEnvs` section to point to the directory where the CA file is mounted. For example, to mount the CA file at `/etc/grid-security/certificates/ca.pem` and set the `RUCIO_CA_FILE` environment variable to `/etc/grid-security/certificates/ca.pem`, you would set the following in the `values.yaml` file:
+
+```yaml
+hostPathMounts:
+  - hostPath: /etc/grid-security/certificates/
+    mountPath: /etc/grid-security/certificates/
+    readOnly: true
+    type: DirectoryOrCreate
+
+additionalEnvs:
+  - name: RUCIO_CA_FILE
+    value: "/etc/grid-security/certificates/ca.pem"
+```
+
+#### CA bundle for host certificates
+For outbound requests made by the WebUI to the Rucio Auth Server and the Rucio Server, the NodeJS application must be able to verify the host certificates of the Rucio Auth Server and the Rucio Server. If your rucio server is not using a [standard web CA bundle](https://github.com/nodejs/node/blob/v4.2.0/src/node_root_certs.h) used by NodeJS, then you must provide a CA that can verify the host certificate of your Rucio server.
+
+Please create a secret which contains the CA bundle of the Rucio Auth Server and the Rucio Server, mount them to the WebUI pods and set the `server_ca_bundle` parameter in the `config.webui` section of `values/yaml`. 
+
+For example, to create a secret with the CA bundle of the Rucio Auth Server and the Rucio Server, you would set the following in the `values.yaml` file:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <releasename>-server-ca
+  namespace: {your_namespace}
+data:
+    ca.pem: {base64 encoded ca.pem}
+type: Opaque
+```
+
+You can then mount the secret into the WebUI pod using the `secretMounts` section. For example:
+
+```yaml
+secretMounts:
+  - name: <releasename>-server-ca
+    mountPath: /etc/grid-security/ca.pem
+    subPath: ca.pem
+```
+
+You must then set the `server_ca_bundle` parameter in the `config.webui` section of the `values.yaml` file to point to the CA file. For example:
+
+```yaml
+config:
+  webui:
+    server_ca_bundle: "/etc/grid-security/ca.pem"
+```
+
 ### Enable HTTPS
+
 To enable HTTPS, you will have to set the `config.webui.useSSL` parameter to `true`. You will also have to adapt the service to port 443:
+
 ```yaml
 service:
   type: ClusterIP
@@ -118,8 +217,9 @@ service:
 Furthermore, you can also change the service type depending on how you want to expose the WebUI. For example, to expose the WebUI using a `LoadBalancer` service, you would set the `service.type` parameter to `LoadBalancer`. To expose the WebUI using a `NodePort` service, you would set the `service.type` parameter to `NodePort` and the `service.nodePort` parameter to the desired port.
 
 ## Ingress
+
 If you want to use and ingress controller to expose the servers you will have to
-configure them separately. In this case the service type should stay as 
+configure them separately. In this case the service type should stay as
 `ClusterIP`. A simple ingress for the api server would like this:
 
     ingress:
@@ -129,28 +229,32 @@ configure them separately. In this case the service type should stay as
         - my.rucio.test
 
 In case you want to use HTTPS with an ingress you should not change the service
-as explained above but instead let the ingress controller handle the TLS 
-connection and then pass the requests using plain HTTP inside the cluster. 
+as explained above but instead let the ingress controller handle the TLS
+connection and then pass the requests using plain HTTP inside the cluster.
 
-You will have to install the valid certificate and key as a secret in the 
+You will have to install the valid certificate and key as a secret in the
 cluster that you can then configure in the ingress definition:
+
 ```bash
 kubectl create secret tls rucio-webui.tls-secret --key=tls.key --cert=tls.crt
 ```
+
 ```yaml
-    ingress:
-      enabled: true
-      path: /
-      hosts:
-        - my.rucio.test
-      tls:
-        - secretName: rucio-server.tls-secret
+ingress:
+  enabled: true
+  path: /
+  hosts:
+    - my.rucio.test
+  tls:
+    - secretName: rucio-server.tls-secret
 ```
 
 ## Additional Configuration
+
 The webui container can be fully configured by providing the environment variables listed [here](https://github.com/rucio/containers/tree/master/webui#configuration). You can specify the `Full Name` of the variable in the `optionalConfig` section of the `values.yaml` file. Please note that the `Full Name` implies the `RUCIO_WEBUI_` prefix or the `RUCIO_HTTPD_` or the `RUCIO_` prefix, depending the on configuration group.
 
 ## Logs
+
 The `config.logs.exposeHttpdLogs` parameter will start a sidecar container that will expose the logs of the Apache server. The logs will be available at the `/var/log/httpd` directory of the container and can also be accessed as `stdout` of the busybox container.
 
 The `config.logs.exposeWebuiLogs` parameter will start a sidecar container that will expose the logs of the WebUI application. The logs will be available at the `/var/log/webui` directory of the container and can also be accessed as `stdout` of the busybox container.

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -61,6 +61,7 @@ secretMounts: []
 config:
   ## values used to configure apache, sets environment variables in the webui container that begin with RUCIO_HTTPD_
   httpd:
+    # server_admin: "webmaster@localhost" 
     mpm_mode: "event"
     start_servers: "1"
     min_spare_threads: "1"
@@ -81,9 +82,9 @@ config:
 
   ## Rucio WebUI specific configuration for apache
   webui:
-    rucio_host: "rucio-server"
-    rucio_auth_host: "rucio-server"
-    hostname: "webui-host"
+    rucio_host: "rucio-server" # hostname of the rucio server, include http:// or https://
+    rucio_auth_host: "rucio-server" # hostname of the rucio-auth server, include http:// or https://
+    hostname: "webui-host" # hostname of the webui ( without http:// or https://, just the hostname, no port or scheme required)
     project_url: "https://rucio.cern.ch"
     multivo_enabled: "False"
     # A csv string of vos containing their short names. For example: "def,atl,cms"
@@ -118,8 +119,26 @@ config:
     exposeHttpdLogs: true
     exposeWebuiLogs: true
 
-# additional environment variables to set in the webui container
+# additional environment variables to set in the webui container as hardcoded key value pairs
 optionalConfig: {}
+#  MY_ENV: "my_value"
+
+
+# hostPathMounts is a list of hostPath mounts to be mounted in the webui container
+hostPathMounts: []
+# - mountPath: /opt/rucio/etc/aliases.conf
+#   hostPath: /etc/rucio/aliases.conf
+#   type: DirectoryOrCreate
+
+# additional volumes to be mounted in the webui container from config maps, secrets, etc.
+additionalEnvs: []
+# - name: MY_ENV
+#   value: "my_value"
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-secret
+#       key: my-key
+
 
 persistentVolumes: {}
 

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -61,7 +61,7 @@ secretMounts: []
 config:
   ## values used to configure apache, sets environment variables in the webui container that begin with RUCIO_HTTPD_
   httpd:
-    # server_admin: "webmaster@localhost" 
+    # server_admin: "webmaster@localhost"
     mpm_mode: "event"
     start_servers: "1"
     min_spare_threads: "1"
@@ -82,9 +82,12 @@ config:
 
   ## Rucio WebUI specific configuration for apache
   webui:
-    rucio_host: "rucio-server" # hostname of the rucio server, include http:// or https://
-    rucio_auth_host: "rucio-server" # hostname of the rucio-auth server, include http:// or https://
-    hostname: "webui-host" # hostname of the webui ( without http:// or https://, just the hostname, no port or scheme required)
+    # hostname of the rucio server, include http:// or https://
+    rucio_host: "rucio-server"
+    # hostname of the rucio-auth server, include http:// or https://
+    rucio_auth_host: "rucio-server"
+    # hostname of the webui ( without http:// or https://, just the hostname, no port or scheme required)
+    hostname: "webui-host"
     project_url: "https://rucio.cern.ch"
     multivo_enabled: "False"
     # A csv string of vos containing their short names. For example: "def,atl,cms"
@@ -123,7 +126,6 @@ config:
 optionalConfig: {}
 #  MY_ENV: "my_value"
 
-
 # hostPathMounts is a list of hostPath mounts to be mounted in the webui container
 hostPathMounts: []
 # - mountPath: /opt/rucio/etc/aliases.conf
@@ -138,7 +140,6 @@ additionalEnvs: []
 #     secretKeyRef:
 #       name: my-secret
 #       key: my-key
-
 
 persistentVolumes: {}
 


### PR DESCRIPTION
…CERTS environment configuration

- Make a clear distinction between the types of CA bundles required by the WebUI i.e. for x509 client certificate verification and for verification of the host certificates of Rucio Server, Rucio Auth Server
- Give examples on how these certificates can be mounted into the pods