### PR TITLE
webui: url encoding option

### DIFF
--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 35.0.1
+version: 35.0.2
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -89,7 +89,7 @@ config:
     # hostname of the webui ( without http:// or https://, just the hostname, no port or scheme required)
     hostname: "webui-host"
     project_url: "https://rucio.cern.ch"
-    # if you DID schema in your policy uses special characters like + or /, set this to true
+    # if your DID schema in your policy uses special characters like + or /, set this to true
     params_encoding_enabled: "False"
     multivo_enabled: "False"
     # A csv string of vos containing their short names. For example: "def,atl,cms"

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -89,6 +89,8 @@ config:
     # hostname of the webui ( without http:// or https://, just the hostname, no port or scheme required)
     hostname: "webui-host"
     project_url: "https://rucio.cern.ch"
+    # if you DID schema in your policy uses special characters like + or /, set this to true
+    params_encoding_enabled: "False"
     multivo_enabled: "False"
     # A csv string of vos containing their short names. For example: "def,atl,cms"
     vo_list: "def"


### PR DESCRIPTION
In order to support DID schemas that use special characters like "/", a new configuration option has been added to the new webui to enable or disable this functionality.

In cases where DID schemas use any such special characters,  the Apache configuration of the Rucio Server most likely uses "AllowEncodedSlashes" or "AllowEncode" directives.

The new `params_encoding_enabled ` in the helm chart config of the Rucio WebUI tells the webui to encode the URI parameters when requests are sent out to the rucio server