### PR TITLE
Enabling VO-agnostic FTS proxy production

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 36.0.1
+version: 36.0.2
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -90,10 +90,14 @@
         - name: {{ $key1 | upper }}
           value: "{{ $val1  }}"
         {{- end}}
+        {{- if ne (coalesce .Values.ftsRenewal.vo (first .Values.ftsRenewal.vos).vo) "none" }}
         - name: RUCIO_VO
           value: {{ coalesce .Values.ftsRenewal.vo (first .Values.ftsRenewal.vos).vo | quote }}
+        {{- end }}
+        {{- if ne (coalesce .Values.ftsRenewal.voms (first .Values.ftsRenewal.vos).voms) "none" }}
         - name: RUCIO_FTS_VOMS
           value: {{ coalesce .Values.ftsRenewal.voms (first .Values.ftsRenewal.vos).voms | quote }}
+        {{- end }}
   {{- if not .Values.ftsRenewal.vo}}
         - name: RUCIO_FTS_SCRIPT
           value: "{{ .Values.ftsRenewal.script }}"

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -418,8 +418,8 @@ ftsRenewal:
   servers: "https://fts3-devel.cern.ch:8446,https://cmsfts3.fnal.gov:8446,https://fts3.cern.ch:8446,https://lcgfts3.gridpp.rl.ac.uk:8446,https://fts3-pilot.cern.ch:8446"
   script: 'default'  # one of: 'default', 'atlas', 'dteam', 'multi_vo', 'tutorial', 'escape'. The associated scripts can be found here: https://github.com/rucio/containers/tree/master/fts-cron
   vos:
-    - vo: "cms"
-      voms: "cms:/cms/Role=production"
+    - vo: "none"
+      voms: "none"
   secretMounts: []
     # - secretName: fts-cert
     #   mountPath: /opt/rucio/certs/usercert.pem


### PR DESCRIPTION
Closes #220 
Tagging @ericvaandering as CMS might be impacted directly.
### Changes 
- Added conditional statement that checks for `"none"` option in `values.yaml`, and if so does not declare `RUCIO_VO` and `RUCIO_FTS_VOMS`. 
- Changed default values for `vo` and `voms` to `"none"`.

### Tests
By running 
```sh
helm template . --kube-version 1.31 --debug --values values.yaml --show-only templates/renew-fts-cronjob.yaml
```
We get: 
```yaml
env:
  - name: RUCIO_FTS_SCRIPT
    value: "default"
  - name: RUCIO_FTS_VO_COUNT
    value: "1"
  - name: RUCIO_FTS_VO_0
    value: none
  - name: RUCIO_FTS_VOMS_0
    value: none
```
In which are correctly missing `RUCIO_VO` and `RUCIO_FTS_VOMS`.

### Follow-up question
Should we avoid creating also `RUCIO_FTS_VO/VOMS_{{ $key }}`?