### PR TITLE
[Server, Daemons]: broader use `rucio.fullname` in names

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 36.0.2
+version: 36.0.3
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/abacus-deployment.yaml
+++ b/charts/rucio-daemons/templates/abacus-deployment.yaml
@@ -19,7 +19,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ .rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/automatic-restart-account.yaml
+++ b/charts/rucio-daemons/templates/automatic-restart-account.yaml
@@ -2,16 +2,16 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-{{ template "rucio.name" . }}-rucio-restart
+  name: {{ template "rucio.fullname" . }}-rucio-restart
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-{{ template "rucio.name" . }}-rucio-restart
+  name: {{ template "rucio.fullname" . }}-rucio-restart
   namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-{{ template "rucio.name" . }}-rucio-restart
+  name: {{ template "rucio.fullname" . }}-rucio-restart
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/rucio-daemons/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-daemons/templates/automatic-restart-cronjob.yaml
@@ -2,14 +2,14 @@
 apiVersion: {{ template "rucio.kubeApiVersion.cronjob" . }}
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-{{ template "rucio.name" . }}-automatic-restart
+  name: {{ template "rucio.fullname" . }}-automatic-restart
 spec:
   schedule: "{{ .Values.automaticRestart.schedule }}"
   jobTemplate:
     spec:
       template:
         spec:
-          serviceAccountName: {{ .Release.Name }}-{{ template "rucio.name" . }}-rucio-restart
+          serviceAccountName: {{ template "rucio.fullname" . }}-rucio-restart
           containers:
             - name: restart-pods
               image: "{{ .Values.automaticRestart.image.repository }}:{{ .Values.automaticRestart.image.tag }}"

--- a/charts/rucio-daemons/templates/automatix-deployment.yaml
+++ b/charts/rucio-daemons/templates/automatix-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/cache-consumer-deployment.yaml
+++ b/charts/rucio-daemons/templates/cache-consumer-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/conveyor-deployment.yaml
+++ b/charts/rucio-daemons/templates/conveyor-deployment.yaml
@@ -19,7 +19,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ .rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/hermes-deployment.yaml
+++ b/charts/rucio-daemons/templates/hermes-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/hermes-legacy-deployment.yaml
+++ b/charts/rucio-daemons/templates/hermes-legacy-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/judge-deployment.yaml
+++ b/charts/rucio-daemons/templates/judge-deployment.yaml
@@ -19,7 +19,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ .rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/minos-deployment.yaml
+++ b/charts/rucio-daemons/templates/minos-deployment.yaml
@@ -19,7 +19,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ .rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/necromancer-deployment.yaml
+++ b/charts/rucio-daemons/templates/necromancer-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/oauth-manager-deployment.yaml
+++ b/charts/rucio-daemons/templates/oauth-manager-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/reaper-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/renew-fts-account.yaml
+++ b/charts/rucio-daemons/templates/renew-fts-account.yaml
@@ -2,16 +2,16 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-rucio-edit
+  name: {{ template "rucio.fullname" . }}-rucio-edit
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-rucio-edit
+  name: {{ template "rucio.fullname" . }}-rucio-edit
   namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-rucio-edit
+  name: {{ template "rucio.fullname" . }}-rucio-edit
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -136,7 +136,7 @@
 apiVersion: {{ template "rucio.kubeApiVersion.cronjob" . }}
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-renew-fts-proxy
+  name: {{ template "rucio.fullname" . }}-renew-fts-proxy
 spec:
   schedule: "{{ .Values.ftsRenewal.schedule }}"
   jobTemplate:
@@ -149,7 +149,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-renew-fts-proxy-on-helm-install
+  name: {{ template "rucio.fullname" . }}-renew-fts-proxy-on-helm-install
   annotations:
     helm.sh/hook: post-install  # Relies on rucio service account, created by this helm chart
     helm.sh/hook-delete-policy: hook-succeeded

--- a/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -1,6 +1,6 @@
 {{- define "rucio-daemons.renew-fts-proxy-jobspec" }}
 {{- if .Values.ftsRenewal.enabled }}
-  serviceAccountName: {{ .Release.Name }}-rucio-edit
+  serviceAccountName: {{ template "rucio.fullname" . }}-rucio-edit
   volumes:
   - name: config-common
     secret:

--- a/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
+++ b/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
@@ -22,7 +22,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/tracer-kronos-deployment.yaml
+++ b/charts/rucio-daemons/templates/tracer-kronos-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
+++ b/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-daemons/templates/undertaker-deployment.yaml
+++ b/charts/rucio-daemons/templates/undertaker-deployment.yaml
@@ -21,7 +21,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ $rucio_daemon }}
+  name: {{ template "rucio.fullname" . }}-{{ $rucio_daemon }}
   labels:
     app: {{ $app_label }}
     app-group: {{ template "rucio.name" . }}

--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 36.0.3
+version: 36.0.4
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/automatic-restart-account.yaml
+++ b/charts/rucio-server/templates/automatic-restart-account.yaml
@@ -2,16 +2,16 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-{{ template "rucio.name" . }}-rucio-restart
+  name: {{ template "rucio.fullname" . }}-rucio-restart
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-{{ template "rucio.name" . }}-rucio-restart
+  name: {{ template "rucio.fullname" . }}-rucio-restart
   namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-{{ template "rucio.name" . }}-rucio-restart
+  name: {{ template "rucio.fullname" . }}-rucio-restart
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/rucio-server/templates/automatic-restart-cronjob.yaml
+++ b/charts/rucio-server/templates/automatic-restart-cronjob.yaml
@@ -2,14 +2,14 @@
 apiVersion: {{ template "rucio.kubeApiVersion.cronjob" . }}
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-{{ template "rucio.name" . }}-automatic-restart
+  name: {{ template "rucio.fullname" . }}-automatic-restart
 spec:
   schedule: "{{ .Values.automaticRestart.schedule }}"
   jobTemplate:
     spec:
       template:
         spec:
-          serviceAccountName: {{ .Release.Name }}-{{ template "rucio.name" . }}-rucio-restart
+          serviceAccountName: {{ template "rucio.fullname" . }}-rucio-restart
           containers:
             - name: restart-pods
               image: "{{ .Values.automaticRestart.image.repository }}:{{ .Values.automaticRestart.image.tag }}"

--- a/charts/rucio-server/templates/renew-fts-account.yaml
+++ b/charts/rucio-server/templates/renew-fts-account.yaml
@@ -2,16 +2,16 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-rucio-edit
+  name: {{ template "rucio.fullname" . }}-rucio-edit
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-rucio-edit
+  name: {{ template "rucio.fullname" . }}-rucio-edit
   namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-rucio-edit
+  name: {{ template "rucio.fullname" . }}-rucio-edit
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/rucio-server/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-server/templates/renew-fts-cronjob.yaml
@@ -1,6 +1,6 @@
 {{- define "rucio-server.renew-fts-proxy-jobspec" }}
 {{- if .Values.ftsRenewal.enabled }}
-  serviceAccountName: {{ .Release.Name }}-rucio-edit
+  serviceAccountName: {{ template "rucio.fullname" . }}-rucio-edit
   volumes:
   - name: config-common
     secret:


### PR DESCRIPTION
Closes #230

Also mostly overrides the changes introduced in https://github.com/rucio/helm-charts/pull/227.

More details in issue.

Using `rucio.fullname` instead of the release name provides (IMHO) better support when using the full name override option as all names will have a name independent of the release name.

Due to the definition of `rucio.fullname` the default behaviour should remain the same.