### PR TITLE
daemons, ui, webui: add policy package support

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 36.0.7
+version: 36.0.8
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/_helpers.tpl
+++ b/charts/rucio-daemons/templates/_helpers.tpl
@@ -51,3 +51,15 @@ Ensures the registry ends with a `/` if set.
     {{- trimSuffix "/" .Values.imageRegistry }}/
   {{- end -}}
 {{- end -}}
+
+{{/*
+Generate policy package PVC Name
+Prepends the release name to the policy package PVC name if specified in values.
+*/}}
+{{- define "rucio.pvc.claimName" -}}
+  {{- if and .Values.policyPackages.enabled .Values.policyPackages.pvc.prependReleaseName -}}
+    {{ .Release.Name }}-{{ .Values.policyPackages.pvc.name }}
+  {{- else -}}
+    {{ .Values.policyPackages.pvc.name }}
+  {{- end -}}
+{{- end -}}

--- a/charts/rucio-daemons/templates/abacus-deployment.yaml
+++ b/charts/rucio-daemons/templates/abacus-deployment.yaml
@@ -74,6 +74,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ .rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -107,6 +112,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce (.component_values.image | default dict).tag .Values.image.tag }}"
@@ -124,6 +132,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
           {{- range $collection := tuple (coalesce .component_values.secretMounts .Values.secretMounts) .component_values.extraSecretMounts }}
           {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -159,6 +171,10 @@ spec:
               value: "{{ .rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{ .daemon_args }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/automatix-deployment.yaml
+++ b/charts/rucio-daemons/templates/automatix-deployment.yaml
@@ -76,6 +76,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -112,6 +117,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -131,6 +139,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
             {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -170,6 +182,10 @@ spec:
             - name: X509_USER_PROXY
               value: "/opt/proxy/x509up"
             {{- end }}
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/cache-consumer-deployment.yaml
+++ b/charts/rucio-daemons/templates/cache-consumer-deployment.yaml
@@ -76,6 +76,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
       {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
       - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -101,6 +106,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -112,6 +120,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
           {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
           {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -147,6 +159,10 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --num-thread {{ $component_values.threads }} {{ end }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/conveyor-deployment.yaml
+++ b/charts/rucio-daemons/templates/conveyor-deployment.yaml
@@ -74,6 +74,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ .rucio_daemon }}
+        {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -107,6 +112,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce (.component_values.image | default dict).tag .Values.image.tag }}"
@@ -124,6 +132,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
           {{- range $collection := tuple (coalesce .component_values.secretMounts .Values.secretMounts) .component_values.extraSecretMounts }}
           {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -159,6 +171,10 @@ spec:
               value: "{{ .rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{ .daemon_args }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
@@ -76,6 +76,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -109,6 +114,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -126,6 +134,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
             {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -169,6 +181,10 @@ spec:
             - name: X509_USER_PROXY
               value: "/opt/proxy/x509up"
             {{- end }}
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/hermes-deployment.yaml
+++ b/charts/rucio-daemons/templates/hermes-deployment.yaml
@@ -76,6 +76,11 @@ spec:
         - name: config-component
           secret:
             secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
 {{ if $component_values.useSSL }}
         - name: usercert
           secret:
@@ -109,6 +114,9 @@ spec:
             path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -126,6 +134,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
             {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -161,6 +173,10 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{ end }} {{ if $component_values.bulk }} --bulk {{ $component_values.bulk }}{{ end }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/hermes-legacy-deployment.yaml
+++ b/charts/rucio-daemons/templates/hermes-legacy-deployment.yaml
@@ -76,6 +76,11 @@ spec:
         - name: config-component
           secret:
             secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
 {{ if $component_values.useSSL }}
         - name: usercert
           secret:
@@ -109,6 +114,9 @@ spec:
             path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -126,6 +134,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
             {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -161,6 +173,10 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{ end }} {{- if $component_values.bulk }} --bulk {{ $component_values.bulk }}{{ end }} {{- if $component_values.sleepTime }} --sleep-time {{ $component_values.sleepTime }}{{ end }} {{- if $component_values.brokerTimeout }} --broker-timeout {{ $component_values.brokerTimeout }}{{ end }} {{- if $component_values.brokerRetry }} --broker-retry {{ $component_values.brokerRetry }}{{ end }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/judge-deployment.yaml
+++ b/charts/rucio-daemons/templates/judge-deployment.yaml
@@ -74,6 +74,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ .rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -107,6 +112,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce (.component_values.image | default dict).tag .Values.image.tag }}"
@@ -124,6 +132,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
           {{- range $collection := tuple (coalesce .component_values.secretMounts .Values.secretMounts) .component_values.extraSecretMounts }}
           {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -159,6 +171,10 @@ spec:
               value: "{{ .rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{ .daemon_args }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/minos-deployment.yaml
+++ b/charts/rucio-daemons/templates/minos-deployment.yaml
@@ -74,6 +74,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ .rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -107,6 +112,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce (.component_values.image | default dict).tag .Values.image.tag }}"
@@ -124,6 +132,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
           {{- range $collection := tuple (coalesce .component_values.secretMounts .Values.secretMounts) .component_values.extraSecretMounts }}
           {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -159,6 +171,10 @@ spec:
               value: "{{ .rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{ .daemon_args }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/necromancer-deployment.yaml
+++ b/charts/rucio-daemons/templates/necromancer-deployment.yaml
@@ -76,6 +76,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -109,6 +114,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -126,6 +134,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
             {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -161,6 +173,10 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{ end }} {{- if $component_values.bulk }} --bulk {{ $component_values.bulk }}{{ end }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/oauth-manager-deployment.yaml
+++ b/charts/rucio-daemons/templates/oauth-manager-deployment.yaml
@@ -76,6 +76,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: ca-volume
         secret:
@@ -106,6 +111,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -121,6 +129,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
           {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
           {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -156,6 +168,10 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{ end }} {{- if $component_values.loopRate }} --loop-rate {{ $component_values.loopRate }}{{ end }} {{- if $component_values.maxRows }} --max-rows {{ $component_values.maxRows }}{{ end }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/policy-package-storage.yaml
+++ b/charts/rucio-daemons/templates/policy-package-storage.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.policyPackages.pvc.createPvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rucio.pvc.claimName" . }}
+spec:
+  storageClassName: {{ .Values.policyPackages.storageClass.name }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.policyPackages.resources.requests.storage }}
+{{- end }}

--- a/charts/rucio-daemons/templates/policy-packages-init.yaml
+++ b/charts/rucio-daemons/templates/policy-packages-init.yaml
@@ -1,0 +1,28 @@
+{{- define "rucio-daemons.policy-package-init-container" -}}
+{{- if .Values.policyPackages.enabled }}
+initContainers:
+- name: install-policy-packages
+  # A slim Python image could be used instead, but using the same image as the base image for the main container ensures that the same Python version is used
+  image: "{{ include "rucio.image.registry" . }}almalinux:9"
+  command:
+    - /bin/bash
+    - -e
+    - -c
+    - |
+      export PYTHONPATH={{ .Values.policyPackages.mountPath }}:$PYTHONPATH
+      {{- range .Values.policyPackages.packages }}
+      if python3 -c "from importlib.metadata import version; assert version({{ .moduleName | squote }}) == {{ .version | squote }}"; then
+          echo "module {{ .moduleName }} version {{ .version }} is already installed"
+      else
+          if [[ {{ .requirement | squote }} == git+* ]]; then
+              dnf install --assumeyes git-all
+          fi
+          dnf install --assumeyes python-pip
+          pip install {{ .requirement }} --target {{ $.Values.policyPackages.mountPath }}
+      fi
+      {{- end }}
+  volumeMounts:
+  - name: policy-package-volume
+    mountPath: {{ .Values.policyPackages.mountPath }}
+{{- end }}
+{{- end }}

--- a/charts/rucio-daemons/templates/reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/reaper-deployment.yaml
@@ -76,6 +76,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -109,6 +114,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -126,6 +134,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
             {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -169,6 +181,10 @@ spec:
             - name: X509_USER_PROXY
               value: "/opt/proxy/x509up"
             {{- end }}
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
+++ b/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
@@ -77,6 +77,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -110,6 +115,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -127,6 +135,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
             {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -162,6 +174,10 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.sleepTime }} --sleep-time {{ $component_values.sleepTime }}{{ end }} {{- if $component_values.inputFile }} --json-file-name {{ $component_values.inputFile }}{{ end }} {{- if $component_values.activeMode }} --active-mode {{ end }} {{- if $component_values.limitSuspiciousFilesOnRse }} --limit-suspicious-files-on-rse {{ $component_values.limitSuspiciousFilesOnRse }}{{ end }} {{- if $component_values.youngerThan }} --younger-than {{ $component_values.youngerThan }}{{ end }}  {{- if $component_values.nAttempts }} --nattempts {{ $component_values.nAttempts }}{{ end }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/tracer-kronos-deployment.yaml
+++ b/charts/rucio-daemons/templates/tracer-kronos-deployment.yaml
@@ -76,6 +76,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
       {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
       - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -96,6 +101,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -107,6 +115,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
             {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -138,6 +150,10 @@ spec:
               value: "kronos"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{end}} {{- if $component_values.sleepTimeFiles }} --sleep-time-files {{ $component_values.sleepTimeFiles }}{{ end }}{{- if $component_values.sleepTimeDatasets }} --sleep-time-datasets {{ $component_values.sleepTimeDatasets }}{{ end }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
+++ b/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
@@ -76,6 +76,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
     {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -109,6 +114,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -126,6 +134,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
             {{- range $key, $val := $collection }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
@@ -161,6 +173,10 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{end}} {{- if $component_values.bulk }} --bulk {{ $component_values.bulk }}{{ end }}{{- if $component_values.sleepTime }} --sleep-time {{ $component_values.sleepTime }}{{ end }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/undertaker-deployment.yaml
+++ b/charts/rucio-daemons/templates/undertaker-deployment.yaml
@@ -76,6 +76,11 @@ spec:
       - name: config-component
         secret:
           secretName: {{ template "rucio.fullname" . }}.config.{{ $rucio_daemon }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
       {{- if .Values.useDeprecatedImplicitSecrets }}
       - name: proxy-volume
         secret:
@@ -106,6 +111,9 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      {{ include "rucio-daemons.policy-package-init-container" . | indent 6 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "rucio.image.registry" . }}{{ .Values.image.repository }}:{{ coalesce ($component_values.image | default dict).tag .Values.image.tag }}"
@@ -117,6 +125,10 @@ spec:
             - name: config-component
               mountPath: /opt/rucio/etc/conf.d/20_component.json
               subPath: component.json
+          {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+          {{- end }}
             {{- if .Values.useDeprecatedImplicitSecrets }}
             - name: proxy-volume
               mountPath: /opt/proxy
@@ -156,6 +168,10 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --total-workers {{ $component_values.threads }}{{end}} {{- if $component_values.chunkSize }} --chunk-size {{ $component_values.chunkSize }}{{ end }}"
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -466,6 +466,34 @@ ftsRenewal:
       cpu: 100m
       memory: 128Mi
 
+policyPackages:
+  enabled: false
+  # Make sure the trailing slash is present
+  mountPath: /opt/policy_packages/
+  # Use underscores instead of hyphens for module names
+  # (e.g. atlas_rucio_policy_package instead of atlas-rucio-policy-package)
+  packages: []
+    # example: install from an index (default is PyPI)
+    # - moduleName: vo_1_policy_package
+    #   requirement: vo_1_policy_package==1.4.0
+    #   version: 1.4.0
+    # example: install from a git repository
+    # - moduleName: vo_2_policy_package
+    #   requirement: git+https://github.com/vo-2/vo-2-policy-package@v0.1.0
+    #   version: 0.1.0
+  pvc:
+    # Set true to create a PVC for the policy packages; leave false if providing it separately.
+    createPvc: false
+    name: policy-package-volume
+    # Whether to prepend the release name to the PVC name provided.
+    prependReleaseName: false
+  resources:
+    requests:
+      # Storage required by the policy packages - resize if needed
+      storage: 100Mi
+  storageClass:
+    name:
+
 automaticRestart:
   enabled: 0
   image:

--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 36.0.1
+version: 36.0.2
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/_helpers.tpl
+++ b/charts/rucio-ui/templates/_helpers.tpl
@@ -51,3 +51,15 @@ Ensures the registry ends with a `/` if set.
     {{- trimSuffix "/" .Values.imageRegistry }}/
   {{- end -}}
 {{- end -}}
+
+{{/*
+Generate policy package PVC Name
+Prepends the release name to the policy package PVC name if specified in values.
+*/}}
+{{- define "rucio.pvc.claimName" -}}
+  {{- if and .Values.policyPackages.enabled .Values.policyPackages.pvc.prependReleaseName -}}
+    {{ .Release.Name }}-{{ .Values.policyPackages.pvc.name }}
+  {{- else -}}
+    {{ .Values.policyPackages.pvc.name }}
+  {{- end -}}
+{{- end -}}

--- a/charts/rucio-ui/templates/deployment.yaml
+++ b/charts/rucio-ui/templates/deployment.yaml
@@ -56,6 +56,11 @@ spec:
           name: {{ template "rucio.fullname" . }}-aliases
       - name: httpdlog
         emptyDir: {}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
       {{- if .Values.useDeprecatedImplicitSecrets }}
       {{- if eq .Values.service.useSSL true }}
       - name: hostcert
@@ -89,6 +94,32 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      initContainers:
+      - name: install-policy-packages
+        # A slim Python image could be used instead, but using the same image as the base image for the main container ensures that the same Python version is used
+        image: "{{ include "rucio.image.registry" . }}almalinux:9"
+        command:
+          - /bin/bash
+          - -e
+          - -c
+          - |
+            export PYTHONPATH={{ .Values.policyPackages.mountPath }}:$PYTHONPATH
+            {{- range .Values.policyPackages.packages }}
+            if python3 -c "from importlib.metadata import version; assert version({{ .moduleName | squote }}) == {{ .version | squote }}"; then
+                echo "module {{ .moduleName }} version {{ .version }} is already installed"
+            else
+                if [[ {{ .requirement | squote }} == git+* ]]; then
+                    dnf install --assumeyes git-all
+                fi
+                dnf install --assumeyes python-pip
+                pip install {{ .requirement }} --target {{ $.Values.policyPackages.mountPath }}
+            fi
+            {{- end }}
+        volumeMounts:
+        - name: policy-package-volume
+          mountPath: {{ .Values.policyPackages.mountPath }}
+{{- end }}
       containers:
 {{- if .Values.exposeErrorLogs }}
         - name: httpd-error-log
@@ -119,6 +150,10 @@ spec:
             - name: aliases
               mountPath: /opt/rucio/etc/aliases.conf
               subPath: aliases.conf
+            {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
+            {{- end }}
             {{- if .Values.useDeprecatedImplicitSecrets }}
             {{- if .Values.service.useSSL }}
             - name: hostcert
@@ -186,6 +221,10 @@ spec:
             - name: RUCIO_ENABLE_SSL
               value: "True"
 {{- end }}
+{{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+{{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-ui/templates/policy-package-storage.yaml
+++ b/charts/rucio-ui/templates/policy-package-storage.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.policyPackages.pvc.createPvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rucio.pvc.claimName" . }}
+spec:
+  storageClassName: {{ .Values.policyPackages.storageClass.name }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.policyPackages.resources.requests.storage }}
+{{- end }}

--- a/charts/rucio-ui/values.yaml
+++ b/charts/rucio-ui/values.yaml
@@ -57,6 +57,34 @@ proxy:
   rucioAuthProxy: "<rucio-auth-server-host>"
   rucioAuthProxyScheme: "https"
 
+policyPackages:
+  enabled: false
+  # Make sure the trailing slash is present
+  mountPath: /opt/policy_packages/
+  # Use underscores instead of hyphens for module names
+  # (e.g. atlas_rucio_policy_package instead of atlas-rucio-policy-package)
+  packages: []
+    # example: install from an index (default is PyPI)
+    # - moduleName: vo_1_policy_package
+    #   requirement: vo_1_policy_package==1.4.0
+    #   version: 1.4.0
+    # example: install from a git repository
+    # - moduleName: vo_2_policy_package
+    #   requirement: git+https://github.com/vo-2/vo-2-policy-package@v0.1.0
+    #   version: 0.1.0
+  pvc:
+    # Set true to create a PVC for the policy packages; leave false if providing it separately.
+    createPvc: false
+    name: policy-package-volume
+    # Whether to prepend the release name to the PVC name provided.
+    prependReleaseName: false
+  resources:
+    requests:
+      # Storage required by the policy packages - resize if needed
+      storage: 100Mi
+  storageClass:
+    name:
+
 ingress:
   enabled: false
   # ingressClassName: traefik

--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 36.0.4
+version: 36.0.5
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/templates/_helpers.tpl
+++ b/charts/rucio-webui/templates/_helpers.tpl
@@ -51,3 +51,15 @@ Ensures the registry ends with a `/` if set.
     {{- trimSuffix "/" .Values.imageRegistry }}/
   {{- end -}}
 {{- end -}}
+
+{{/*
+Generate policy package PVC Name
+Prepends the release name to the policy package PVC name if specified in values.
+*/}}
+{{- define "rucio.pvc.claimName" -}}
+  {{- if and .Values.policyPackages.enabled .Values.policyPackages.pvc.prependReleaseName -}}
+    {{ .Release.Name }}-{{ .Values.policyPackages.pvc.name }}
+  {{- else -}}
+    {{ .Values.policyPackages.pvc.name }}
+  {{- end -}}
+{{- end -}}

--- a/charts/rucio-webui/templates/deployment.yaml
+++ b/charts/rucio-webui/templates/deployment.yaml
@@ -67,6 +67,11 @@ spec:
             - key: tls.key
               path: hostkey.pem
       {{- end }}
+      {{- if .Values.policyPackages.enabled }}
+      - name: policy-package-volume
+        persistentVolumeClaim:
+          claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
       - name: webui-log
         emptyDir: {}
       {{- if .Values.useDeprecatedImplicitSecrets }}
@@ -102,6 +107,32 @@ spec:
           path: {{ $val.hostPath }}
       {{- end}}
       {{- end}}
+{{- if .Values.policyPackages.enabled }}
+      initContainers:
+      - name: install-policy-packages
+        # A slim Python image could be used instead, but using the same image as the base image for the main container ensures that the same Python version is used
+        image: "{{ include "rucio.image.registry" . }}almalinux:9"
+        command:
+          - /bin/bash
+          - -e
+          - -c
+          - |
+            export PYTHONPATH={{ .Values.policyPackages.mountPath }}:$PYTHONPATH
+            {{- range .Values.policyPackages.packages }}
+            if python3 -c "from importlib.metadata import version; assert version({{ .moduleName | squote }}) == {{ .version | squote }}"; then
+                echo "module {{ .moduleName }} version {{ .version }} is already installed"
+            else
+                if [[ {{ .requirement | squote }} == git+* ]]; then
+                    dnf install --assumeyes git-all
+                fi
+                dnf install --assumeyes python-pip
+                pip install {{ .requirement }} --target {{ $.Values.policyPackages.mountPath }}
+            fi
+            {{- end }}
+        volumeMounts:
+        - name: policy-package-volume
+          mountPath: {{ .Values.policyPackages.mountPath }}
+{{- end }}
       containers:
       {{- if .Values.config.logs.exposeHttpdLogs }}
         - name: httpd-error-log
@@ -139,6 +170,10 @@ spec:
             {{- if .Values.config.logs.exposeWebuiLogs }}
             - name: webui-log
               mountPath: /root/.pm2/logs/
+            {{- end }}
+            {{- if .Values.policyPackages.enabled }}
+            - name: policy-package-volume
+              mountPath: {{ .Values.policyPackages.mountPath }}
             {{- end }}
             {{- if .Values.useDeprecatedImplicitSecrets }}
             {{- if .Values.useSSL }}
@@ -223,6 +258,10 @@ spec:
             - name: RUCIO_WEBUI_ENABLE_SSL
               value: "True"
           {{- end }}
+          {{- if .Values.policyPackages.enabled}}
+            - name: PYTHONPATH
+              value: {{.Values.policyPackages.mountPath}}:${PYTHONPATH}
+          {{- end}}
 {{- with .Values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-webui/templates/policy-package-storage.yaml
+++ b/charts/rucio-webui/templates/policy-package-storage.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.policyPackages.pvc.createPvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rucio.pvc.claimName" . }}
+spec:
+  storageClassName: {{ .Values.policyPackages.storageClass.name }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.policyPackages.resources.requests.storage }}
+{{- end }}

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -56,6 +56,34 @@ service:
 
 useDeprecatedImplicitSecrets: false
 
+policyPackages:
+  enabled: false
+  # Make sure the trailing slash is present
+  mountPath: /opt/policy_packages/
+  # Use underscores instead of hyphens for module names
+  # (e.g. atlas_rucio_policy_package instead of atlas-rucio-policy-package)
+  packages: []
+    # example: install from an index (default is PyPI)
+    # - moduleName: vo_1_policy_package
+    #   requirement: vo_1_policy_package==1.4.0
+    #   version: 1.4.0
+    # example: install from a git repository
+    # - moduleName: vo_2_policy_package
+    #   requirement: git+https://github.com/vo-2/vo-2-policy-package@v0.1.0
+    #   version: 0.1.0
+  pvc:
+    # Set true to create a PVC for the policy packages; leave false if providing it separately.
+    createPvc: false
+    name: policy-package-volume
+    # Whether to prepend the release name to the PVC name provided.
+    prependReleaseName: false
+  resources:
+    requests:
+      # Storage required by the policy packages - resize if needed
+      storage: 100Mi
+  storageClass:
+    name:
+
 ingress:
   enabled: false
   # ingressClassName: traefik


### PR DESCRIPTION
For the daemons, test rendering to ensure the include works:

```
      initContainers:
      - name: install-policy-packages
        # A slim Python image could be used instead, but using the same image as the base image for the main container ensures that the same Python version is used
        image: almalinux:9
        command:
          - /bin/bash
          - -e
          - -c
          - |
            export PYTHONPATH=/opt/policy_packages/:$PYTHONPATH
            if python3 -c "from importlib.metadata import version; assert version('vo_1_policy_package') == '1.4.0'"; then
                echo "module vo_1_policy_package version 1.4.0 is already installed"
            else
                if [[ 'vo_1_policy_package==1.4.0' == git+* ]]; then
                    dnf install --assumeyes git-all
                fi
                dnf install --assumeyes python-pip
                pip install vo_1_policy_package==1.4.0 --target /opt/policy_packages/
            fi
            if python3 -c "from importlib.metadata import version; assert version('vo_2_policy_package') == '0.1.0'"; then
                echo "module vo_2_policy_package version 0.1.0 is already installed"
            else
                if [[ 'git+https://github.com/vo-2/vo-2-policy-package@v0.1.0' == git+* ]]; then
                    dnf install --assumeyes git-all
                fi
                dnf install --assumeyes python-pip
                pip install git+https://github.com/vo-2/vo-2-policy-package@v0.1.0 --target /opt/policy_packages/
            fi
        volumeMounts:
        - name: policy-package-volume
          mountPath: /opt/policy_packages/
      containers:
        - name: rucio-daemons
          image: "rucio/rucio-daemons:release-34.2.0"
          imagePullPolicy: Always
          volumeMounts:
            - name: proxy-volume
              mountPath: /opt/proxy
            - name: ca-volume
              mountPath: /opt/certs
            - name: config-common
              mountPath: /opt/rucio/etc/conf.d/10_common.json
              subPath: common.json
            - name: config-component
              mountPath: /opt/rucio/etc/conf.d/20_component.json
              subPath: component.json
            - name: policy-package-volume
              mountPath: /opt/policy_packages/
          ports:
            - name: metrics
              containerPort: 8080
              protocol: TCP
          env:
            - name: RUCIO_OVERRIDE_CONFIGS
              value: "/opt/rucio/etc/conf.d/"
            - name: RUCIO_DAEMON
              value: "abacus-account"
            - name: RUCIO_DAEMON_ARGS
              value: "--threads 1"
            - name: PYTHONPATH
              value: /opt/policy_packages/:${PYTHONPATH}
          resources:
            limits:
              cpu: 700m
              memory: 200Mi
            requests:
              cpu: 700m
```
