### PR TITLE
[webui]: Prevent duplicates between config and env for RUCIO_WEBUI

### DIFF
--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 36.0.1
+version: 36.0.2
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/templates/deployment.yaml
+++ b/charts/rucio-webui/templates/deployment.yaml
@@ -160,9 +160,15 @@ spec:
             - name: RUCIO_HTTPD_{{ $key | snakecase | upper }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- $explicitEnvMap := dict }}
+            {{- range .Values.additionalEnvs }}
+            {{- $explicitEnvMap = merge $explicitEnvMap (dict (index . "name") (index . "valueFrom")) }}
+            {{- end }}
             {{- range $key, $val := .Values.config.webui }}
+            {{- if not (hasKey $explicitEnvMap (printf "RUCIO_WEBUI_%s" $key | upper)) }}
             - name: RUCIO_WEBUI_{{ $key | snakecase | upper }}
               value: {{ $val | quote }}
+            {{- end }}
             {{- end }}
             {{ range $provider, $data := .Values.config.oidc_providers }}
             {{- range $key, $val := $data }}


### PR DESCRIPTION
Closes #242 

Now values explicitly set as env variables e.g. `RUCIO_WEBUI_RUCIO_HOST` won't be overriden by the `config.webui` section. The reason why one might need to set values as env instead of in the config section is because it's not possible to use secrets / config maps here. It would be really nice to do so but that is for another conversation.