### PR TITLE
[server, webui]: Add `hostname` value, optional support for `external-dns`

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 36.0.5
+version: 36.0.6
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/service.yaml
+++ b/charts/rucio-server/templates/service.yaml
@@ -8,9 +8,16 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.service.annotations }}
+{{- $annotations := merge (dict) .Values.service.annotations }}
+{{- if .Values.service.useExternalDNS }}
+  {{- if not .Values.hostname }}
+    {{- fail "Error: 'hostname' must be defined when 'useExternalDNS' is enabled." }}
+  {{- end }}
+  {{- $_ := set $annotations "external-dns.alpha.kubernetes.io/hostname" .Values.hostname }}
+{{- end }}
+{{- if $annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -21,6 +21,8 @@ errorLogsExporterResources:
 # Set to true to enable SSL support for the different servers to be able accept X509 certificates and proxies.
 useSSL: false
 
+hostname: null
+
 image:
   repository: rucio/rucio-server
   tag: release-36.2.0
@@ -46,6 +48,7 @@ service:
   loadBalancerClass: null
   externalTrafficPolicy: null
   allocateLoadBalancerNodePorts: true
+  useExternalDNS: false
 
 strategy:
   type: RollingUpdate

--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 36.0.1
+version: 36.0.2
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/templates/service.yaml
+++ b/charts/rucio-webui/templates/service.yaml
@@ -8,9 +8,16 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with .Values.service.annotations }}
+{{- $annotations := merge (dict) .Values.service.annotations }}
+{{- if .Values.service.useExternalDNS }}
+  {{- if not .Values.hostname }}
+    {{- fail "Error: 'hostname' must be defined when 'useExternalDNS' is enabled." }}
+  {{- end }}
+  {{- $_ := set $annotations "external-dns.alpha.kubernetes.io/hostname" .Values.hostname }}
+{{- end }}
+{{- if $annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -26,6 +26,8 @@ imageRegistry: ""
 
 useSSL: true
 
+hostname: null
+
 service:
   type: ClusterIP
   port: 80
@@ -41,6 +43,7 @@ service:
   loadBalancerClass: null
   externalTrafficPolicy: null
   allocateLoadBalancerNodePorts: true
+  useExternalDNS: false
 
 useDeprecatedImplicitSecrets: false
 


### PR DESCRIPTION
Closes https://github.com/rucio/helm-charts/issues/248

We have been trying `external-dns` to manage the dns records for our services with good results.

`external-dns` uses annotations in the services in order to work.

Getting the correct configuration with the current rucio charts was not straightforward and it required having duplicated config values (you don't want to hardcode the hostname in multiple places). This can be fixed by adding a configuration value named `hostname` which then can be referenced elsewhere.

The way to enable `external-dns` is via a disabled-by-default flag named `useExternalDNS` which adds the necessary annotations. While the current design which allows arbitrary annotations works in theory, it requires duplication of values.

I refactored the section related to the service annotations since now we have more than one source of annotations.