### PR TITLE
[server, webui, daemons]: Support setting tls secrets by name

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 36.0.4
+version: 36.0.5
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -15,6 +15,16 @@
       {{- end }}
   {{- end}}
   {{- end}}
+  {{- if .Values.ftsRenewal.tlsSecretName }}
+  - name: tls-secret-volume
+    secret:
+      secretName: {{ .Values.ftsRenewal.tlsSecretName }}
+      items:
+        - key: tls.crt
+          path: usercert.pem
+        - key: tls.key
+          path: userkey.pem
+  {{- end }}
   {{- if .Values.useDeprecatedImplicitSecrets }}
   {{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
   - name: longproxy
@@ -54,6 +64,16 @@
         - name: config-common
           mountPath: /opt/rucio/etc/conf.d/10_common.json
           subPath: common.json
+  {{- if .Values.ftsRenewal.tlsSecretName }}
+        - name: tls-secret-volume
+          mountPath: /opt/rucio/certs/usercert.pem
+          subPath: usercert.pem
+          readOnly: true
+        - name: tls-secret-volume
+          mountPath: /opt/rucio/keys/userkey.pem
+          subPath: userkey.pem
+          readOnly: true
+  {{- end }}
   {{- if .Values.useDeprecatedImplicitSecrets }}
   {{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
         - name: longproxy

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -420,6 +420,7 @@ ftsRenewal:
     pullPolicy: Always
   servers: "https://fts3-devel.cern.ch:8446,https://cmsfts3.fnal.gov:8446,https://fts3.cern.ch:8446,https://lcgfts3.gridpp.rl.ac.uk:8446,https://fts3-pilot.cern.ch:8446"
   script: 'default'  # one of: 'default', 'atlas', 'dteam', 'multi_vo', 'tutorial', 'escape'. The associated scripts can be found here: https://github.com/rucio/containers/tree/master/fts-cron
+  tlsSecretName: null
   vos:
     - vo: "none"
       voms: "none"

--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 36.0.6
+version: 36.0.7
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -51,6 +51,16 @@ spec:
       {{- end }}
       - name: httpdlog
         emptyDir: {}
+      {{- if .Values.tlsSecretName }}
+      - name: tls-secret-volume
+        secret:
+          secretName: {{ .Values.tlsSecretName }}
+          items:
+            - key: tls.crt
+              path: hostcert.pem
+            - key: tls.key
+              path: hostkey.pem
+      {{- end }}
       {{- if .Values.policyPackages.enabled }}
       - name: policy-package-volume
         persistentVolumeClaim:
@@ -160,6 +170,16 @@ spec:
           - name: ca-volume
             mountPath: /opt/certs
           {{- end }}
+          {{- end }}
+          {{- if .Values.tlsSecretName }}
+          - name: tls-secret-volume
+            mountPath: /etc/grid-security/hostcert.pem
+            subPath: hostcert.pem
+            readOnly: true
+          - name: tls-secret-volume
+            mountPath: /etc/grid-security/hostkey.pem
+            subPath: hostkey.pem
+            readOnly: true
           {{- end }}
           {{- if .Values.policyPackages.enabled }}
           - name: policy-package-volume

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -23,6 +23,8 @@ useSSL: false
 
 hostname: null
 
+tlsSecretName: null
+
 image:
   repository: rucio/rucio-server
   tag: release-36.2.0

--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 36.0.2
+version: 36.0.3
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/templates/deployment.yaml
+++ b/charts/rucio-webui/templates/deployment.yaml
@@ -53,6 +53,16 @@ spec:
           secretName: {{ template "rucio.fullname" . }}.config.yaml
       - name: httpdlog
         emptyDir: {}
+      {{- if .Values.tlsSecretName }}
+      - name: tls-secret-volume
+        secret:
+          secretName: {{ .Values.tlsSecretName }}
+          items:
+            - key: tls.crt
+              path: hostcert.pem
+            - key: tls.key
+              path: hostkey.pem
+      {{- end }}
       - name: webui-log
         emptyDir: {}
       {{- if .Values.useDeprecatedImplicitSecrets }}
@@ -139,6 +149,16 @@ spec:
               subPath: ca.pem
             {{- end}}
             {{- end}}
+            {{- if .Values.tlsSecretName }}
+            - name: tls-secret-volume
+              mountPath: /etc/grid-security/hostcert.pem
+              subPath: hostcert.pem
+              readOnly: true
+            - name: tls-secret-volume
+              mountPath: /etc/grid-security/hostkey.pem
+              subPath: hostkey.pem
+              readOnly: true
+            {{- end }}
             {{- range $key, $val := .Values.secretMounts }}
             - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}
               mountPath: {{ $val.mountPath }}

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -28,6 +28,8 @@ useSSL: true
 
 hostname: null
 
+tlsSecretName: null
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
Closes https://github.com/rucio/helm-charts/issues/246

Add new field `tlsSecretName` (unset by default) which can be used to point to a tls secret which will then be used to setup the public/private keys for tls.

I think this provides a cleaner approach compared to asking the user to mount some secrets into some specific paths.

Before this change you would need to do:

```
  secretMounts:
    - secretFullName: rucio-tls-host-cert
      mountPath: /etc/grid-security/hostcert.pem
      subPath: tls.crt
    - secretFullName: rucio-tls-host-key
      mountPath: /etc/grid-security/hostkey.pem
      subPath: tls.key
```

After this can optionally be condensed into:

```
tlsSecretName: rucio-tls-host
```

Besides the reduced lines of code needed, now (IMHO) it's easier for a new user to figure out how to setup tls from looking at the helm chart.

This change just adds an alternative way to configure tls, the old way still works fine.
