### PR TITLE
[daemons]: Option to have shared env variables between all daemons

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 36.0.5
+version: 36.0.6
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/abacus-deployment.yaml
+++ b/charts/rucio-daemons/templates/abacus-deployment.yaml
@@ -155,6 +155,9 @@ spec:
               value: "{{ .rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{ .daemon_args }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with .component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/automatix-deployment.yaml
+++ b/charts/rucio-daemons/templates/automatix-deployment.yaml
@@ -166,6 +166,9 @@ spec:
             - name: X509_USER_PROXY
               value: "/opt/proxy/x509up"
             {{- end }}
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/cache-consumer-deployment.yaml
+++ b/charts/rucio-daemons/templates/cache-consumer-deployment.yaml
@@ -143,6 +143,9 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --num-thread {{ $component_values.threads }} {{ end }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/conveyor-deployment.yaml
+++ b/charts/rucio-daemons/templates/conveyor-deployment.yaml
@@ -155,6 +155,9 @@ spec:
               value: "{{ .rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{ .daemon_args }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with .component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
@@ -165,6 +165,9 @@ spec:
             - name: X509_USER_PROXY
               value: "/opt/proxy/x509up"
             {{- end }}
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/hermes-deployment.yaml
+++ b/charts/rucio-daemons/templates/hermes-deployment.yaml
@@ -157,6 +157,9 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{ end }} {{ if $component_values.bulk }} --bulk {{ $component_values.bulk }}{{ end }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/hermes-legacy-deployment.yaml
+++ b/charts/rucio-daemons/templates/hermes-legacy-deployment.yaml
@@ -157,6 +157,9 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{ end }} {{- if $component_values.bulk }} --bulk {{ $component_values.bulk }}{{ end }} {{- if $component_values.sleepTime }} --sleep-time {{ $component_values.sleepTime }}{{ end }} {{- if $component_values.brokerTimeout }} --broker-timeout {{ $component_values.brokerTimeout }}{{ end }} {{- if $component_values.brokerRetry }} --broker-retry {{ $component_values.brokerRetry }}{{ end }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/judge-deployment.yaml
+++ b/charts/rucio-daemons/templates/judge-deployment.yaml
@@ -155,6 +155,9 @@ spec:
               value: "{{ .rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{ .daemon_args }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with .component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/minos-deployment.yaml
+++ b/charts/rucio-daemons/templates/minos-deployment.yaml
@@ -155,6 +155,9 @@ spec:
               value: "{{ .rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{ .daemon_args }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with .component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/necromancer-deployment.yaml
+++ b/charts/rucio-daemons/templates/necromancer-deployment.yaml
@@ -157,6 +157,9 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{ end }} {{- if $component_values.bulk }} --bulk {{ $component_values.bulk }}{{ end }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/oauth-manager-deployment.yaml
+++ b/charts/rucio-daemons/templates/oauth-manager-deployment.yaml
@@ -152,6 +152,9 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{ end }} {{- if $component_values.loopRate }} --loop-rate {{ $component_values.loopRate }}{{ end }} {{- if $component_values.maxRows }} --max-rows {{ $component_values.maxRows }}{{ end }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/reaper-deployment.yaml
@@ -165,6 +165,9 @@ spec:
             - name: X509_USER_PROXY
               value: "/opt/proxy/x509up"
             {{- end }}
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
+++ b/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
@@ -158,6 +158,9 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.sleepTime }} --sleep-time {{ $component_values.sleepTime }}{{ end }} {{- if $component_values.inputFile }} --json-file-name {{ $component_values.inputFile }}{{ end }} {{- if $component_values.activeMode }} --active-mode {{ end }} {{- if $component_values.limitSuspiciousFilesOnRse }} --limit-suspicious-files-on-rse {{ $component_values.limitSuspiciousFilesOnRse }}{{ end }} {{- if $component_values.youngerThan }} --younger-than {{ $component_values.youngerThan }}{{ end }}  {{- if $component_values.nAttempts }} --nattempts {{ $component_values.nAttempts }}{{ end }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/tracer-kronos-deployment.yaml
+++ b/charts/rucio-daemons/templates/tracer-kronos-deployment.yaml
@@ -134,6 +134,9 @@ spec:
               value: "kronos"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{end}} {{- if $component_values.sleepTimeFiles }} --sleep-time-files {{ $component_values.sleepTimeFiles }}{{ end }}{{- if $component_values.sleepTimeDatasets }} --sleep-time-datasets {{ $component_values.sleepTimeDatasets }}{{ end }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
+++ b/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
@@ -157,6 +157,9 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --threads {{ $component_values.threads }}{{end}} {{- if $component_values.bulk }} --bulk {{ $component_values.bulk }}{{ end }}{{- if $component_values.sleepTime }} --sleep-time {{ $component_values.sleepTime }}{{ end }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/templates/undertaker-deployment.yaml
+++ b/charts/rucio-daemons/templates/undertaker-deployment.yaml
@@ -152,6 +152,9 @@ spec:
               value: "{{ $rucio_daemon }}"
             - name: RUCIO_DAEMON_ARGS
               value: "{{- if $component_values.threads }} --total-workers {{ $component_values.threads }}{{end}} {{- if $component_values.chunkSize }} --chunk-size {{ $component_values.chunkSize }}{{ end }}"
+{{- with .Values.additionalEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end}}
 {{- with $component_values.additionalEnvs }}
 {{ toYaml . | indent 12 }}
 {{- end}}

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -43,6 +43,9 @@ imagePullSecrets: []
 imageRegistry: ""
 # imageRegistry: registry.cern.ch/docker.io
 
+# env variables common to all daemons
+additionalEnvs: []
+
 strategy:
   type: RollingUpdate
   rollingUpdate:


### PR DESCRIPTION
The change introduces an optional way to add environment variables shared between all daemons.

This reduces code duplication for shared envs between daemons such as database configuration etc.

Also closes https://github.com/rucio/helm-charts/issues/247 since the main motivation of the issue was that the env variable approach resulted in too much code duplication. I don't think we need another way to configure the drabase anymore.
