### PR TITLE
Add optional deployment annotations

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 36.0.6
+version: 36.0.7
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/abacus-deployment.yaml
+++ b/charts/rucio-daemons/templates/abacus-deployment.yaml
@@ -26,6 +26,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .component_count }}
   selector:

--- a/charts/rucio-daemons/templates/automatix-deployment.yaml
+++ b/charts/rucio-daemons/templates/automatix-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/cache-consumer-deployment.yaml
+++ b/charts/rucio-daemons/templates/cache-consumer-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/conveyor-deployment.yaml
+++ b/charts/rucio-daemons/templates/conveyor-deployment.yaml
@@ -26,6 +26,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .component_count }}
   selector:

--- a/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/hermes-deployment.yaml
+++ b/charts/rucio-daemons/templates/hermes-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/hermes-legacy-deployment.yaml
+++ b/charts/rucio-daemons/templates/hermes-legacy-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/judge-deployment.yaml
+++ b/charts/rucio-daemons/templates/judge-deployment.yaml
@@ -26,6 +26,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .component_count }}
   selector:

--- a/charts/rucio-daemons/templates/minos-deployment.yaml
+++ b/charts/rucio-daemons/templates/minos-deployment.yaml
@@ -26,6 +26,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .component_count }}
   selector:

--- a/charts/rucio-daemons/templates/necromancer-deployment.yaml
+++ b/charts/rucio-daemons/templates/necromancer-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/oauth-manager-deployment.yaml
+++ b/charts/rucio-daemons/templates/oauth-manager-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/reaper-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
+++ b/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
@@ -29,6 +29,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/tracer-kronos-deployment.yaml
+++ b/charts/rucio-daemons/templates/tracer-kronos-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
+++ b/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/templates/undertaker-deployment.yaml
+++ b/charts/rucio-daemons/templates/undertaker-deployment.yaml
@@ -28,6 +28,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ $component_count }}
   selector:

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -47,6 +47,10 @@ imageRegistry: ""
 additionalEnvs: []
 
 # Additional annotations to be added to the deployment
+# Example usage:
+# deploymentAnnotations:
+#   reloader.stakater.com/auto: "true"
+#   foo: "bar"
 deploymentAnnotations: {}
 
 strategy:

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -46,6 +46,9 @@ imageRegistry: ""
 # env variables common to all daemons
 additionalEnvs: []
 
+# Additional annotations to be added to the deployment
+deploymentAnnotations: {}
+
 strategy:
   type: RollingUpdate
   rollingUpdate:

--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 36.0.7
+version: 36.0.8
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -9,6 +9,11 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -52,6 +52,9 @@ service:
   allocateLoadBalancerNodePorts: true
   useExternalDNS: false
 
+# Additional annotations to be added to the deployment
+deploymentAnnotations: {}
+
 strategy:
   type: RollingUpdate
   rollingUpdate:

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -53,6 +53,10 @@ service:
   useExternalDNS: false
 
 # Additional annotations to be added to the deployment
+# Example usage:
+# deploymentAnnotations:
+#   reloader.stakater.com/auto: "true"
+#   foo: "bar"
 deploymentAnnotations: {}
 
 strategy:

--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 36.0.3
+version: 36.0.4
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/templates/deployment.yaml
+++ b/charts/rucio-webui/templates/deployment.yaml
@@ -21,6 +21,10 @@ metadata:
     chart: {{ template "rucio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -24,6 +24,9 @@ imagePullSecrets: []
 imageRegistry: ""
 # imageRegistry: registry.cern.ch/docker.io
 
+# Additional annotations to be added to the deployment
+deploymentAnnotations: {}
+
 useSSL: true
 
 hostname: null

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -25,6 +25,10 @@ imageRegistry: ""
 # imageRegistry: registry.cern.ch/docker.io
 
 # Additional annotations to be added to the deployment
+# Example usage:
+# deploymentAnnotations:
+#   reloader.stakater.com/auto: "true"
+#   foo: "bar"
 deploymentAnnotations: {}
 
 useSSL: true


### PR DESCRIPTION
Closes #250 

Via annotations one can configure reloader to reload the related service whenever a change to a secret or configmap happens:

```
  deploymentAnnotations:
    reloader.stakater.com/auto: "true"
```

By default deployments will be reloaded whenever any secret/map mounted on them is changed. This can be configured with great granularity via annotations either in the deployment or secrets (you only want to reload whenever one particular secret changes, etc.). I think the default behaviour is good enough.

Via this strategy the server will reload whenever the policy package is updated, or daemons will reload whenever the certificate is updated by the cronjob.