### PR TITLE
[server]: Add optional support of policy package in ephemeral volume

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 37.0.0
+version: 37.0.1
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -68,8 +68,12 @@ spec:
       {{- end }}
       {{- if .Values.policyPackages.enabled }}
       - name: policy-package-volume
+      {{- if .Values.policyPackages.ephemeralVolume }}
+        emptyDir: {}
+      {{- else }}
         persistentVolumeClaim:
           claimName: {{ include "rucio.pvc.claimName" . }}
+      {{- end }}
       {{- end }}
       {{- range $key, $val := .Values.secretMounts }}
       - name: {{ coalesce $val.volumeName $val.secretName $val.secretFullName }}

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -165,6 +165,11 @@ ftsRenewal:
 
 policyPackages:
   enabled: false
+
+  # Use an ephemeral volume to install the policy package.
+  # This means that the policy package will need to be installed on every pod restart but no PV/PVC are needed
+  ephemeralVolume: false
+
   # Make sure the trailing slash is present
   mountPath: /opt/policy_packages/
   # Use underscores instead of hyphens for module names


### PR DESCRIPTION
By setting

```
policyPackages:
  ephemeralVolume: true
```

the policy package will be installed in a ephmeral volume, meaning that it will be reinstalled every time the pod restarts.

The upside of this approach is that we do not need PV/PVC so we can run it on a k8s cluster without any storage.