### PR TITLE
[ui]: Allow proxy / host settings to be set by env

### DIFF
--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 37.0.2
+version: 37.0.3
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/deployment.yaml
+++ b/charts/rucio-ui/templates/deployment.yaml
@@ -215,11 +215,14 @@ spec:
             - name: {{ $key1 | upper }}
               value: "{{ $val1  }}"
             {{- end}}
-
+{{- if not .Values.proxy.configurationFromEnv }}
             - name: RUCIO_PROXY
               value: {{ .Values.proxy.rucioProxy }}
             - name: RUCIO_AUTH_PROXY
               value: {{ .Values.proxy.rucioAuthProxy }}
+            - name: RUCIO_HOSTNAME
+              value: {{ .Values.httpd_config.rucio_hostname }}
+{{- end }}
 {{- if .Values.proxy.rucioProxyScheme }}
             - name: RUCIO_PROXY_SCHEME
               value: {{ .Values.proxy.rucioProxyScheme }}
@@ -228,8 +231,6 @@ spec:
             - name: RUCIO_AUTH_PROXY_SCHEME
               value: {{ .Values.proxy.rucioAuthProxyScheme }}
 {{- end }}
-            - name: RUCIO_HOSTNAME
-              value: {{ .Values.httpd_config.rucio_hostname }}
             - name: RUCIO_OVERRIDE_CONFIGS
               value: "/opt/rucio/etc/conf.d/"
             - name: RUCIO_LOG_FORMAT

--- a/charts/rucio-ui/values.yaml
+++ b/charts/rucio-ui/values.yaml
@@ -61,6 +61,8 @@ proxy:
   rucioProxyScheme: "https"
   rucioAuthProxy: "<rucio-auth-server-host>"
   rucioAuthProxyScheme: "https"
+  # If this flag is set to true, use environment variables (RUCIO_PROXY, RUCIO_AUTH_PROXY, RUCIO_HOSTNAME) instead
+  configurationFromEnv: false
 
 policyPackages:
   enabled: false


### PR DESCRIPTION
Adds a new (disabled by default) option `proxy.configurationFromEnv` that allows setting the RUCIO_PROXY, RUCIO_AUTH_PROXY, RUCIO_HOSTNAME env variables explicitly. 

If this is not set, there will be duplicated env variables in the yaml resulting in an invalid configuration.