### PR TITLE
32 LTS: Run Helm chart linting against target branch, rather than default branch

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -4,6 +4,9 @@ on:
   - pull_request
   - push
 
+env:
+  TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest
@@ -29,13 +32,13 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --target-branch ${{ env.TARGET_BRANCH }})
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --debug --validate-maintainers=false --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --debug --validate-maintainers=false --target-branch ${{ env.TARGET_BRANCH }}
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.4.0


### PR DESCRIPTION
fix rucio#283