### PR TITLE
Clear policy package path before upgrading

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 37.0.3
+version: 37.0.4
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/policy-packages-init.yaml
+++ b/charts/rucio-daemons/templates/policy-packages-init.yaml
@@ -18,6 +18,7 @@ initContainers:
               dnf install --assumeyes git-all
           fi
           dnf install --assumeyes python-pip
+          pip uninstall --yes {{ .moduleName }}
           pip install {{ .requirement }} --target {{ $.Values.policyPackages.mountPath }}
       fi
       {{- end }}

--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 37.0.3
+version: 37.0.4
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -130,6 +130,7 @@ spec:
                     dnf install --assumeyes git-all
                 fi
                 dnf install --assumeyes python-pip
+                pip uninstall --yes {{ .moduleName }}
                 pip install {{ .requirement }} --target {{ $.Values.policyPackages.mountPath }}
             fi
             {{- end }}

--- a/charts/rucio-ui/Chart.yaml
+++ b/charts/rucio-ui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-ui
-version: 37.0.5
+version: 37.0.6
 apiVersion: v1
 description: A Helm chart to deploy webui servers for Rucio
 keywords:

--- a/charts/rucio-ui/templates/deployment.yaml
+++ b/charts/rucio-ui/templates/deployment.yaml
@@ -123,6 +123,7 @@ spec:
                     dnf install --assumeyes git-all
                 fi
                 dnf install --assumeyes python-pip
+                pip uninstall --yes {{ .moduleName }}
                 pip install {{ .requirement }} --target {{ $.Values.policyPackages.mountPath }}
             fi
             {{- end }}

--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 37.0.3
+version: 37.0.4
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/templates/deployment.yaml
+++ b/charts/rucio-webui/templates/deployment.yaml
@@ -126,6 +126,7 @@ spec:
                     dnf install --assumeyes git-all
                 fi
                 dnf install --assumeyes python-pip
+                pip uninstall --yes {{ .moduleName }}
                 pip install {{ .requirement }} --target {{ $.Values.policyPackages.mountPath }}
             fi
             {{- end }}


### PR DESCRIPTION
Fix #289 

## Test (server)
starting with `atlas_rucio_policy_package==0.4.0`

- first run
```
Collecting atlas_rucio_policy_package==0.4.0
  Downloading atlas_rucio_policy_package-0.4.0-py3-none-any.whl (23 kB)
Installing collected packages: atlas-rucio-policy-package
Successfully installed atlas-rucio-policy-package-0.4.0
```

- in server
```
>>> import atlas_rucio_policy_package
>>> atlas_rucio_policy_package
<module 'atlas_rucio_policy_package' from '/opt/policy_packages/atlas_rucio_policy_package/__init__.py'>
>>> print(version("atlas_rucio_policy_package"))
>>> from importlib.metadata import version
>>> print(version("atlas_rucio_policy_package"))
0.4.0
```

modified to
```
- moduleName: atlas_rucio_policy_package

requirement: atlas_rucio_policy_package==0.6.0

version: 0.6.0
```

```
helm upgrade -f charts/rucio-server/values.yaml test-release charts/rucio-server     
```

init container logs
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError
...
Complete!
Collecting atlas_rucio_policy_package==0.6.0
  Downloading atlas_rucio_policy_package-0.6.0-py3-none-any.whl (23 kB)
Installing collected packages: atlas-rucio-policy-package
Successfully installed atlas-rucio-policy-package-0.6.0
```

(note that the `AssertionError` is expected, it occurs due to the policy package already being installed)

- in server
```
>>> import atlas_rucio_policy_package
>>> atlas_rucio_policy_package
<module 'atlas_rucio_policy_package' from '/opt/policy_packages/atlas_rucio_policy_package/__init__.py'>
>>> import version
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'version'
>>> from importlib import version
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'version' from 'importlib' (/usr/lib64/python3.9/importlib/__init__.py)
>>> from importlib.metadata import version
>>> print(version("atlas_rucio_policy_package"))
0.6.0
```
