### PR TITLE
Allow option to not mount x509 to all daemons, only those that need it

### DIFF
--- a/charts/rucio-daemons/Chart.yaml
+++ b/charts/rucio-daemons/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-daemons
-version: 38.0.0
+version: 38.0.1
 apiVersion: v1
 description: A Helm chart to deploy daemons for Rucio
 keywords:

--- a/charts/rucio-daemons/templates/abacus-deployment.yaml
+++ b/charts/rucio-daemons/templates/abacus-deployment.yaml
@@ -90,6 +90,10 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
+    {{- else if .Values.proxyCertificateSecret.name }}
+      - name: proxy-certificate-volume
+        secret:
+          secretName: {{ .Values.proxyCertificateSecret.name }}
     {{- end }}
       {{- range $collection := tuple (coalesce .component_values.secretMounts .Values.secretMounts) .component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
@@ -129,6 +133,10 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+          {{- else if .Values.proxyCertificateSecret.name }}
+            - name: proxy-certificate-volume
+              mountPath: {{ .Values.proxyCertificateSecret.mountPath }}
+              subPath: {{ .Values.proxyCertificateSecret.subPath }}
           {{- end }}
             - name: config-common
               mountPath: /opt/rucio/etc/conf.d/10_common.json

--- a/charts/rucio-daemons/templates/conveyor-deployment.yaml
+++ b/charts/rucio-daemons/templates/conveyor-deployment.yaml
@@ -90,6 +90,10 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
+    {{- else if .Values.proxyCertificateSecret.name }}
+      - name: proxy-certificate-volume
+        secret:
+          secretName: {{ .Values.proxyCertificateSecret.name }}
     {{- end }}
       {{- range $collection := tuple (coalesce .component_values.secretMounts .Values.secretMounts) .component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
@@ -129,6 +133,10 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+          {{- else if .Values.proxyCertificateSecret.name }}
+            - name: proxy-certificate-volume
+              mountPath: {{ .Values.proxyCertificateSecret.mountPath }}
+              subPath: {{ .Values.proxyCertificateSecret.subPath }}
           {{- end }}
             - name: config-common
               mountPath: /opt/rucio/etc/conf.d/10_common.json

--- a/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/dark-reaper-deployment.yaml
@@ -92,6 +92,10 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle-reaper
+    {{- else if .Values.proxyCertificateSecret.name }}
+      - name: proxy-certificate-volume
+        secret:
+          secretName: {{ .Values.proxyCertificateSecret.name }}
     {{- end }}
       {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
@@ -131,6 +135,10 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /etc/grid-security/certificates
+          {{- else if .Values.proxyCertificateSecret.name }}
+            - name: proxy-certificate-volume
+              mountPath: {{ .Values.proxyCertificateSecret.mountPath }}
+              subPath: {{ .Values.proxyCertificateSecret.subPath }}
           {{- end }}
             - name: config-common
               mountPath: /opt/rucio/etc/conf.d/10_common.json

--- a/charts/rucio-daemons/templates/judge-deployment.yaml
+++ b/charts/rucio-daemons/templates/judge-deployment.yaml
@@ -90,6 +90,10 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
+    {{- else if and .includeProxyCert .Values.proxyCertificateSecret.name }}
+      - name: proxy-certificate-volume
+        secret:
+          secretName: {{ .Values.proxyCertificateSecret.name }}
     {{- end }}
       {{- range $collection := tuple (coalesce .component_values.secretMounts .Values.secretMounts) .component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
@@ -129,6 +133,10 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+          {{- else if and .includeProxyCert .Values.proxyCertificateSecret.name }}
+            - name: proxy-certificate-volume
+              mountPath: {{ .Values.proxyCertificateSecret.mountPath }}
+              subPath: {{ .Values.proxyCertificateSecret.subPath }}
           {{- end }}
             - name: config-common
               mountPath: /opt/rucio/etc/conf.d/10_common.json
@@ -217,6 +225,7 @@ spec:
 {{- $args = set $args "component_values" .Values.judgeCleaner }}
 {{- $args = set $args "component_count" .Values.judgeCleanerCount }}
 {{- $args = set $args "daemon_args" (include "rucio-daemons.judge-cleaner-daemon-args" .Values.judgeCleaner) }}
+{{- $args = set $args "includeProxyCert" true }}
 {{- include "rucio-daemons.judge-deployment" $args }}
 {{ end }}
 
@@ -229,6 +238,7 @@ spec:
 {{- $args = set $args "component_values" .Values.judgeEvaluator }}
 {{- $args = set $args "component_count" .Values.judgeEvaluatorCount }}
 {{- $args = set $args "daemon_args" (include "rucio-daemons.judge-evaluator-daemon-args" .Values.judgeEvaluator) }}
+{{- $args = set $args "includeProxyCert" false }}
 {{- include "rucio-daemons.judge-deployment" $args }}
 {{ end }}
 
@@ -241,6 +251,7 @@ spec:
 {{- $args = set $args "component_values" .Values.judgeInjector }}
 {{- $args = set $args "component_count" .Values.judgeInjectorCount }}
 {{- $args = set $args "daemon_args" (include "rucio-daemons.judge-injector-daemon-args" .Values.judgeInjector) }}
+{{- $args = set $args "includeProxyCert" false }}
 {{- include "rucio-daemons.judge-deployment" $args }}
 {{ end }}
 
@@ -253,5 +264,6 @@ spec:
 {{- $args = set $args "component_values" .Values.judgeRepairer }}
 {{- $args = set $args "component_count" .Values.judgeRepairerCount }}
 {{- $args = set $args "daemon_args" (include "rucio-daemons.judge-repairer-daemon-args" .Values.judgeRepairer) }}
+{{- $args = set $args "includeProxyCert" false }}
 {{- include "rucio-daemons.judge-deployment" $args }}
 {{ end }}

--- a/charts/rucio-daemons/templates/minos-deployment.yaml
+++ b/charts/rucio-daemons/templates/minos-deployment.yaml
@@ -90,6 +90,10 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
+    {{- else if .Values.proxyCertificateSecret.name }}
+      - name: proxy-certificate-volume
+        secret:
+          secretName: {{ .Values.proxyCertificateSecret.name }}
     {{- end }}
       {{- range $collection := tuple (coalesce .component_values.secretMounts .Values.secretMounts) .component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
@@ -129,6 +133,10 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+          {{- else if .Values.proxyCertificateSecret.name }}
+            - name: proxy-certificate-volume
+              mountPath: {{ .Values.proxyCertificateSecret.mountPath }}
+              subPath: {{ .Values.proxyCertificateSecret.subPath }}
           {{- end }}
             - name: config-common
               mountPath: /opt/rucio/etc/conf.d/10_common.json

--- a/charts/rucio-daemons/templates/necromancer-deployment.yaml
+++ b/charts/rucio-daemons/templates/necromancer-deployment.yaml
@@ -92,6 +92,10 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
+    {{- else if .Values.proxyCertificateSecret.name }}
+      - name: proxy-certificate-volume
+        secret:
+          secretName: {{ .Values.proxyCertificateSecret.name }}
     {{- end }}
       {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
@@ -131,6 +135,10 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+          {{- else if .Values.proxyCertificateSecret.name }}
+            - name: proxy-certificate-volume
+              mountPath: {{ .Values.proxyCertificateSecret.mountPath }}
+              subPath: {{ .Values.proxyCertificateSecret.subPath }}
           {{- end }}
             - name: config-common
               mountPath: /opt/rucio/etc/conf.d/10_common.json

--- a/charts/rucio-daemons/templates/reaper-deployment.yaml
+++ b/charts/rucio-daemons/templates/reaper-deployment.yaml
@@ -92,6 +92,10 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle-reaper
+    {{- else if .Values.proxyCertificateSecret.name }}
+      - name: proxy-certificate-volume
+        secret:
+          secretName: {{ .Values.proxyCertificateSecret.name }}
     {{- end }}
       {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
@@ -131,6 +135,10 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /etc/grid-security/certificates
+          {{- else if .Values.proxyCertificateSecret.name }}
+            - name: proxy-certificate-volume
+              mountPath: {{ .Values.proxyCertificateSecret.mountPath }}
+              subPath: {{ .Values.proxyCertificateSecret.subPath }}
           {{- end }}
             - name: config-common
               mountPath: /opt/rucio/etc/conf.d/10_common.json

--- a/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
+++ b/charts/rucio-daemons/templates/renew-fts-cronjob.yaml
@@ -135,10 +135,13 @@
   {{- if .Values.useDeprecatedImplicitSecrets }}
         - name: RUCIO_FTS_SECRETS
           value: "{{ .Release.Name }}-rucio-x509up"
-  {{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
+    {{- if or (eq .Values.ftsRenewal.vo "atlas") (eq .Values.ftsRenewal.vo "dteam") }}
         - name: RUCIO_LONG_PROXY
           value: {{ .Values.ftsRenewal.longProxy | quote }}
-  {{- end }}
+    {{- end }}
+  {{- else if .Values.proxyCertificateSecret.name }}
+        - name: RUCIO_FTS_SECRETS
+          value: {{.Values.proxyCertificateSecret.name | quote }}
   {{- end }}
   {{- with .Values.ftsRenewal.additionalEnvs }}
 {{ toYaml . | indent 8 }}

--- a/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
+++ b/charts/rucio-daemons/templates/replica-recoverer-deployment.yaml
@@ -93,6 +93,10 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
+    {{- else if .Values.proxyCertificateSecret.name }}
+      - name: proxy-certificate-volume
+        secret:
+          secretName: {{ .Values.proxyCertificateSecret.name }}
     {{- end }}
       {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
@@ -132,6 +136,10 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+          {{- else if .Values.proxyCertificateSecret.name }}
+            - name: proxy-certificate-volume
+              mountPath: {{ .Values.proxyCertificateSecret.mountPath }}
+              subPath: {{ .Values.proxyCertificateSecret.subPath }}
           {{- end }}
             - name: config-common
               mountPath: /opt/rucio/etc/conf.d/10_common.json

--- a/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
+++ b/charts/rucio-daemons/templates/transmogrifier-deployment.yaml
@@ -92,6 +92,10 @@ spec:
       - name: ca-volume
         secret:
           secretName: {{ .Release.Name }}-rucio-ca-bundle
+    {{- else if .Values.proxyCertificateSecret.name }}
+      - name: proxy-certificate-volume
+        secret:
+          secretName: {{ .Values.proxyCertificateSecret.name }}
     {{- end }}
       {{- range $collection := tuple (coalesce $component_values.secretMounts .Values.secretMounts) $component_values.extraSecretMounts }}
       {{- range $key, $val := $collection }}
@@ -131,6 +135,10 @@ spec:
               mountPath: /opt/proxy
             - name: ca-volume
               mountPath: /opt/certs
+          {{- else if .Values.proxyCertificateSecret.name }}
+            - name: proxy-certificate-volume
+              mountPath: {{ .Values.proxyCertificateSecret.mountPath }}
+              subPath: {{ .Values.proxyCertificateSecret.subPath }}
           {{- end }}
             - name: config-common
               mountPath: /opt/rucio/etc/conf.d/10_common.json

--- a/charts/rucio-daemons/values.yaml
+++ b/charts/rucio-daemons/values.yaml
@@ -521,6 +521,15 @@ secretMounts: []
   #   mountPath: /opt/rucio/etc/gcs_rucio.json
   #   subPath: gcs_rucio.json
 
+
+# The recommended way to configure the x509 proxy certificate
+# Instead of mounting it as a secret in all daemons, if you set it here, it will only be mounted on the daemons that need it
+# If this is enabled, do not mount the x509 proxy secret manually
+proxyCertificateSecret:
+  name: null
+  subPath: x509up
+  mountPath: /opt/proxy/x509up
+
 ## common config values used to configure the Rucio daemons
 config:
   # accounts:


### PR DESCRIPTION
Closes #297 

```
ProxyCertificateSecret:
  name: name-of-secret
  key: x509up
  mountPath: /opt/proxy/x509up
```

option controlls this setting, if defined the x509 will only be mounted in the daemons that need it. Also the fts cronjob will write the secret to this value so its not need to be double specified in the config.

This is motivated because in our deployments we reload whenever a mount changes, this makes all daemons be reloaded when the fts cronjob triggers but since the x509 proxy is not needed everywhere, this change will prevent unnecessary restarts.

**I added the proxy cert to the daemons that I thought needed it. I may be wrong. Please let me know exactly which daemons need access to the x509 and I will update the PR.**