### PR TITLE
Make httpd error log image configurable

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 38.0.0
+version: 38.0.1
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -141,7 +141,7 @@ spec:
       containers:
 {{- if .Values.exposeErrorLogs }}
         - name: httpd-error-log
-          image: "{{ include "rucio.image.registry" . }}busybox"
+          image: "{{ include "rucio.image.registry" . }}{{ .Values.errorLog.image }}:{{ .Values.errorLog.tag }}"
           args: [/bin/sh, -c, 'tail -n+1 -F /var/log/httpd/error_log']
           volumeMounts:
           - name: httpdlog

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -18,6 +18,10 @@ errorLogsExporterResources:
     cpu: 20m
     memory: 20Mi
 
+errorLog:
+  image: busybox
+  tag: latest
+
 # Set to true to enable SSL support for the different servers to be able accept X509 certificates and proxies.
 useSSL: false
 


### PR DESCRIPTION
In CTAO, we need to avoid getting images from dockerhub due to their restrictive pull limits.

We have our own images in a harbor and a proxy for dockerhub there as well, however, these are different namespaces and the current chart doesn't allow us to get 

- the busybox image from harbor.cta-observatory.org/proxy_cache/busybox
- the rucio images from harbor.cta-observatory.org/dpps/bdms-rucio-server

This adds the missing values configuration to enable this.
