### PR TITLE
Added resources for install-policy-packages container

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 38.0.4
+version: 38.0.5
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -137,6 +137,10 @@ spec:
         volumeMounts:
         - name: policy-package-volume
           mountPath: {{ .Values.policyPackages.mountPath }}
+{{- if .Values.policyPackages.containerResources }}
+        resources:
+{{ toYaml .Values.policyPackages.containerResources | indent 10 }}
+{{- end }}
 {{- end }}
       containers:
 {{- if .Values.exposeErrorLogs }}

--- a/charts/rucio-server/values.yaml
+++ b/charts/rucio-server/values.yaml
@@ -197,6 +197,13 @@ policyPackages:
     requests:
       # Storage required by the policy packages - resize if needed
       storage: 100Mi
+  containerResources:
+    requests:
+      cpu: 500m
+      memory: 500Mi
+    limits:
+      cpu: 500m
+      memory: 500Mi
   storageClass:
     name:
 

--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 38.0.1
+version: 38.0.2
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/templates/deployment.yaml
+++ b/charts/rucio-webui/templates/deployment.yaml
@@ -133,6 +133,10 @@ spec:
         volumeMounts:
         - name: policy-package-volume
           mountPath: {{ .Values.policyPackages.mountPath }}
+{{- if .Values.policyPackages.containerResources }}
+        resources:
+{{ toYaml .Values.policyPackages.containerResources | indent 10 }}
+{{- end }}
 {{- end }}
       containers:
       {{- if .Values.config.logs.exposeHttpdLogs }}

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -81,6 +81,13 @@ policyPackages:
     requests:
       # Storage required by the policy packages - resize if needed
       storage: 100Mi
+  containerResources:
+    requests:
+      cpu: 500m
+      memory: 500Mi
+    limits:
+      cpu: 500m
+      memory: 500Mi
   storageClass:
     name:
 


### PR DESCRIPTION
Would close #317 

Not sure what the best key would be, but this would be the implementation. `policyPackages.resource` is being used by the `pvc`, so I didn't rename it.

I also haven't optimized the cpu or memory requests. I would assume pip might not need that many resources.