### PR TITLE
Prevent redirect for readiness probes

### DIFF
--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 39.0.0
+version: 39.0.1
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/Chart.yaml
+++ b/charts/rucio-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-server
-version: 41.0.0
+version: 41.0.1
 apiVersion: v1
 description: A Helm chart to deploy servers for Rucio
 keywords:

--- a/charts/rucio-server/templates/deployment.yaml
+++ b/charts/rucio-server/templates/deployment.yaml
@@ -258,7 +258,7 @@ spec:
 {{- end }}
           readinessProbe:
             httpGet:
-              path: /ping
+              path: /ping/
 {{- if .Values.useSSL }}
               port: 444
               scheme: HTTPS
@@ -270,7 +270,7 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           livenessProbe:
             httpGet:
-              path: /ping
+              path: /ping/
 {{- if .Values.useSSL }}
               port: 444
               scheme: HTTPS


### PR DESCRIPTION
In our deployment we observe these logs on the server:

```
│ rucio-server [2026-01-25 11:27:15]    10.244.0.51    _gateway    -    aXX-EwYUDVckA2Fh8qI1MAAAAQA    308    1711    245    3283572    "GET /ping HTTP/1.1"    "-"    "kube-probe/1.34"   │
│ rucio-server [2026-01-25 11:27:15]    10.244.0.51    _gateway    -    aXX-E6xq_YR1ydXMBK0lHQAAAYA    308    1711    245    2722894    "GET /ping HTTP/1.1"    "-"    "kube-probe/1.34"   │
│ rucio-server [2026-01-25 11:27:18]    10.244.0.51    _gateway    -    aXX-FgYUDVckA2Fh8qI1MQAAAQI    200    1751    21    3256241    "GET /ping/ HTTP/1.1"    "-"    "kube-probe/1.34"   │
│ rucio-server [2026-01-25 11:27:18]    10.244.0.51    _gateway    -    aXX-FgYUDVckA2Fh8qI1MgAAAQM    200    1751    21    3255756    "GET /ping/ HTTP/1.1"    "-"    "kube-probe/1.34"
```

So the initial probe gets a 308 redirect from `/ping` to `/ping/` and only then the ping succeeds.

Directly using `/ping/` should avoid these redirects.