### PR TITLE
docs(rucio-webui): document optional OIDC provider icon_url

### DIFF
--- a/charts/rucio-webui/Chart.yaml
+++ b/charts/rucio-webui/Chart.yaml
@@ -1,5 +1,5 @@
 name: rucio-webui
-version: 41.0.0
+version: 41.1.0
 apiVersion: v1
 description: A Helm chart to deploy the new Rucio Webui
 keywords:

--- a/charts/rucio-webui/values.yaml
+++ b/charts/rucio-webui/values.yaml
@@ -159,6 +159,9 @@ config:
       refresh_token_url: ""
       userinfo_url: ""
       redirect_url: ""
+      # optional: URL to a raster icon (png/jpg) shown on this provider's login button.
+      # It is downloaded locally at container start and served via next/image.
+      icon_url: ""
 
   vo:
     def:


### PR DESCRIPTION
Adds a documented optional `icon_url` to the example `cern` OIDC provider in
`values.yaml`. The chart already renders per-provider keys generically, so this
surfaces the option (rendered as `RUCIO_WEBUI_OIDC_PROVIDER_<NAME>_ICON_URL`)
without a template change.

The icon is downloaded locally at container start and served via `next/image`.
Related to rucio/webui#805 (WebUI: rucio/webui#806, containers: rucio/containers#530).

Verified with `helm template` that `RUCIO_WEBUI_OIDC_PROVIDER_CERN_ICON_URL` is emitted.